### PR TITLE
fix e2e test helper to set context on client config

### DIFF
--- a/changelog/v0.1.3/fix-test-util.yaml
+++ b/changelog/v0.1.3/fix-test-util.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix multicluster test util so we get a config with the given current context.

--- a/codegen/render/kube_multicluster_test.go
+++ b/codegen/render/kube_multicluster_test.go
@@ -101,12 +101,12 @@ var _ = WithRemoteClusterContextDescribe("Multicluster", func() {
 		})
 		AfterEach(func() {
 			cancel()
-			for _, kubeContext := range []string{"", remoteContext} {
-				cfg, err := kubeutils.GetConfigWithContext("", os.Getenv("KUBECONFIG"), kubeContext)
-				Expect(err).NotTo(HaveOccurred())
-				kube := kubernetes.NewForConfigOrDie(cfg)
-				kube.CoreV1().Secrets(ns).Delete(kcSecret.Name, &v1.DeleteOptions{})
-			}
+			cfg, err := kubeutils.GetConfigWithContext("", os.Getenv("KUBECONFIG"), "")
+			Expect(err).NotTo(HaveOccurred())
+			kube := kubernetes.NewForConfigOrDie(cfg)
+			// clean up the kubeconfig secret
+			err = kube.CoreV1().Secrets(ns).Delete(kcSecret.Name, &v1.DeleteOptions{})
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		Describe("clientset", func() {

--- a/test/test_config.go
+++ b/test/test_config.go
@@ -61,8 +61,11 @@ func MustManagerNotStarted(ns string) manager.Manager {
 func MustClientConfigWithContext(context string) *api.Config {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	loadingRules.ExplicitPath = os.Getenv("KUBECONFIG")
-	configOverrides := &clientcmd.ConfigOverrides{CurrentContext: context}
-	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ConfigAccess().GetStartingConfig()
+	// NOTE: ConfigOverrides are NOT propagated to `GetStartingConfig()`, so we set CurrentContext on the resulting config
+	cfg, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, nil).ConfigAccess().GetStartingConfig()
 	Expect(err).NotTo(HaveOccurred())
+	if context != "" {
+		cfg.CurrentContext = context
+	}
 	return cfg
 }


### PR DESCRIPTION
Fix e2e test helper such that context is set on resulting client config. Also update multicluster reconciler now that this bug is fixed, and the tests actually run against two clusters.