### PR TITLE
fix chartgen

### DIFF
--- a/changelog/v0.3.3/fix-chartgen.yaml
+++ b/changelog/v0.3.3/fix-chartgen.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix bug that causes chart generation to produce no files when a `FilterTemplate` function is not provided in the `codegen.Command`.
+    issueLink: https://github.com/solo-io/skv2/issues/47

--- a/codegen/render/chart_renderer.go
+++ b/codegen/render/chart_renderer.go
@@ -58,15 +58,16 @@ func (r ChartRenderer) Render(chart model.Chart) ([]OutFile, error) {
 
 	files = append(files, customFiles...)
 
-	var filteredFiles []OutFile
-	if chart.FilterTemplate != nil {
+	if chart.FilterTemplate == nil {
+		var filteredFiles []OutFile
 		for _, file := range files {
 			if chart.FilterTemplate(file.Path) {
 				continue
 			}
 			filteredFiles = append(filteredFiles, file)
 		}
+		files = filteredFiles
 	}
 
-	return filteredFiles, nil
+	return files, nil
 }

--- a/codegen/render/chart_renderer.go
+++ b/codegen/render/chart_renderer.go
@@ -58,7 +58,7 @@ func (r ChartRenderer) Render(chart model.Chart) ([]OutFile, error) {
 
 	files = append(files, customFiles...)
 
-	if chart.FilterTemplate == nil {
+	if chart.FilterTemplate != nil {
 		var filteredFiles []OutFile
 		for _, file := range files {
 			if chart.FilterTemplate(file.Path) {


### PR DESCRIPTION
fixes an issue where the helm chart is not generated unless a `FilterTemplate` function is provided
BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/47