### PR TITLE
allow overriding proto package for proto-based resources

### DIFF
--- a/changelog/v0.7.0/proto-package-override.yaml
+++ b/changelog/v0.7.0/proto-package-override.yaml
@@ -1,0 +1,9 @@
+changelog:
+- type: NEW_FEATURE
+  description: >
+    When using proto-based types for the `Spec` and `Status` fields of a resource, we currently require that the
+    messages for these types are defined in a proto package that matches the group name of the resource.
+    This change adds a new `ProtoPackage` option that can be used to override the name of the proto packages we inspect
+    when looking for the messages. If the options in unspecified, it defaults to the group name of the resource.
+  issueLink: https://github.com/solo-io/skv2/issues/98
+

--- a/codegen/cmd.go
+++ b/codegen/cmd.go
@@ -257,15 +257,16 @@ func (c Command) addDescriptorsToGroup(grp *render.Group, descriptors []*skmodel
 		// attach the proto messages for spec and status to each resource
 		// these are processed by renderers at later stages
 		for _, fileDescriptor := range descriptors {
-			findFieldMessage := func(fieldType model.Type) bool {
+
+			findFieldMessageFunc := func(fieldType *model.Type) bool {
 				matchingProtoPackage := fieldType.ProtoPackage
 				if matchingProtoPackage == "" {
 					// default to the resource API Group name
 					matchingProtoPackage = resource.Group.Group
 				}
 				if fileDescriptor.GetPackage() == matchingProtoPackage {
-					if specMessage := fileDescriptor.GetMessage(fieldType.Name); specMessage != nil {
-						fieldType.Message = specMessage
+					if message := fileDescriptor.GetMessage(fieldType.Name); message != nil {
+						fieldType.Message = message
 						fieldType.GoPackage = fileDescriptor.GetOptions().GetGoPackage()
 						descriptorMap[fileDescriptor.GetName()+fileDescriptor.GetPackage()] = fileDescriptor
 						return true
@@ -277,15 +278,11 @@ func (c Command) addDescriptorsToGroup(grp *render.Group, descriptors []*skmodel
 
 			// find message for spec
 			if !foundSpec {
-				foundSpec = findFieldMessage(resource.Spec.Type)
+				foundSpec = findFieldMessageFunc(&resource.Spec.Type)
 			}
 
 			if resource.Status != nil {
-				findFieldMessage(resource.Status.Type)
-				if statusMessage := fileDescriptor.GetMessage(resource.Status.Type.Name); statusMessage != nil {
-					resource.Status.Type.Message = statusMessage
-					descriptorMap[fileDescriptor.GetName()+fileDescriptor.GetPackage()] = fileDescriptor
-				}
+				findFieldMessageFunc(&resource.Status.Type)
 			}
 
 		}

--- a/codegen/cmd.go
+++ b/codegen/cmd.go
@@ -276,7 +276,9 @@ func (c Command) addDescriptorsToGroup(grp *render.Group, descriptors []*skmodel
 			}
 
 			// find message for spec
-			foundSpec = findFieldMessage(resource.Spec.Type)
+			if !foundSpec {
+				foundSpec = findFieldMessage(resource.Spec.Type)
+			}
 
 			if resource.Status != nil {
 				findFieldMessage(resource.Status.Type)

--- a/codegen/model/resource.go
+++ b/codegen/model/resource.go
@@ -144,11 +144,8 @@ type Type struct {
 	GoPackage string
 
 	/*
-
-		The proto package containing the type, if different than group root api directory (where the resource itself lives).
-		Will be set automatically for proto-based types.
-
-		If unset, SKv2 uses the (Kubernetes) API Group for the Type.
+		The proto package containing the type, if different than the Group name of the Resource.
+		If unset, SKv2 uses the Group name of the Resource that specifies this Type.
 	*/
 	ProtoPackage string
 }

--- a/codegen/model/resource.go
+++ b/codegen/model/resource.go
@@ -142,4 +142,13 @@ type Type struct {
 		If unset, SKv2 uses the default types package for the type.
 	*/
 	GoPackage string
+
+	/*
+
+		The proto package containing the type, if different than group root api directory (where the resource itself lives).
+		Will be set automatically for proto-based types.
+
+		If unset, SKv2 uses the (Kubernetes) API Group for the Type.
+	*/
+	ProtoPackage string
 }

--- a/codegen/render/proto_types_renderer.go
+++ b/codegen/render/proto_types_renderer.go
@@ -23,7 +23,6 @@ type ProtoCodeRenderer struct {
 func RenderProtoTypes(grp Group) ([]OutFile, error) {
 	defaultKubeCodeRenderer := ProtoCodeRenderer{
 		templateRenderer: DefaultTemplateRenderer,
-		GoModule:         grp.Module,
 		ApiRoot:          grp.ApiRoot,
 	}
 
@@ -33,7 +32,7 @@ func RenderProtoTypes(grp Group) ([]OutFile, error) {
 func (r ProtoCodeRenderer) RenderProtoHelpers(grp Group) ([]OutFile, error) {
 
 	// only render proto helpers for proto groups in the current module
-	if !grp.HasProtos() || grp.Module != r.GoModule {
+	if !grp.HasProtos() {
 		return nil, nil
 	}
 

--- a/codegen/render/proto_types_renderer.go
+++ b/codegen/render/proto_types_renderer.go
@@ -23,6 +23,7 @@ type ProtoCodeRenderer struct {
 func RenderProtoTypes(grp Group) ([]OutFile, error) {
 	defaultKubeCodeRenderer := ProtoCodeRenderer{
 		templateRenderer: DefaultTemplateRenderer,
+		GoModule:         grp.Module,
 		ApiRoot:          grp.ApiRoot,
 	}
 


### PR DESCRIPTION
When using proto-based types for the `Spec` and `Status` fields of a resource, we currently require that the messages for these types are defined in a proto package that matches the group name of the resource.

This change adds a new `ProtoPackage` option that can be used to override the name of the proto packages we inspect when looking for the messages. If the options in unspecified, it defaults to the group name of the resource.

BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/98