### PR TITLE
input Snapshot builder: check CRD registration

### DIFF
--- a/changelog/v0.12.0/check-crd-access.yaml
+++ b/changelog/v0.12.0/check-crd-access.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: BREAKING_CHANGE
+  description: '*Contrib:* Extend the options for the Input Snapshot Builder to verify that the backing CRD for a an input resource has been registered to the source cluster. Note that skv2 does not differentiate between non-CRD and CRD-based resources, meaning that the user should be careful not to unintentionally perform CRD checks for non-CRD resources.'
+  issueLink: https://github.com/solo-io/skv2/issues/140

--- a/codegen/render/kube_multicluster_test.go
+++ b/codegen/render/kube_multicluster_test.go
@@ -188,7 +188,7 @@ var _ = WithRemoteClusterContextDescribe("Multicluster", func() {
 			})
 
 			It("works when a loop is registered before the watcher is started", func() {
-				loop := controller.NewMulticlusterPaintReconcileLoop("pre-run-paint", cw)
+				loop := controller.NewMulticlusterPaintReconcileLoop("pre-run-paint", cw, reconcile.Options{})
 
 				paintMap := &concurrentPaintMap{}
 				paintDeletes := &concurrentRequestMap{}
@@ -212,7 +212,7 @@ var _ = WithRemoteClusterContextDescribe("Multicluster", func() {
 			})
 
 			It("works when a kubeconfig secret is deleted and recreated", func() {
-				loop := controller.NewMulticlusterPaintReconcileLoop("paint", cw)
+				loop := controller.NewMulticlusterPaintReconcileLoop("paint", cw, reconcile.Options{})
 
 				paintMap := &concurrentPaintMap{}
 				paintDeletes := &concurrentRequestMap{}
@@ -289,7 +289,7 @@ var _ = WithRemoteClusterContextDescribe("Multicluster", func() {
 				err := cw.Run(masterManager)
 				Expect(err).NotTo(HaveOccurred())
 
-				loop := controller.NewMulticlusterPaintReconcileLoop("mid-run-paint", cw)
+				loop := controller.NewMulticlusterPaintReconcileLoop("mid-run-paint", cw, reconcile.Options{})
 
 				paintMap := &concurrentPaintMap{}
 				deleteMap := &concurrentRequestMap{}

--- a/codegen/templates/code/controller/multicluster_reconcilers.gotmpl
+++ b/codegen/templates/code/controller/multicluster_reconcilers.gotmpl
@@ -66,8 +66,8 @@ func (m *multicluster{{ $resource.Kind }}ReconcileLoop) AddMulticluster{{ $resou
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticluster{{ $resource.Kind }}ReconcileLoop(name string, cw multicluster.ClusterWatcher) Multicluster{{ $resource.Kind }}ReconcileLoop {
-	return &multicluster{{ $resource.Kind }}ReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &{{ $import_prefix }}.{{ $resource.Kind }}{})}
+func NewMulticluster{{ $resource.Kind }}ReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) Multicluster{{ $resource.Kind }}ReconcileLoop {
+	return &multicluster{{ $resource.Kind }}ReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &{{ $import_prefix }}.{{ $resource.Kind }}{}, options)}
 }
 
 type generic{{ $resource.Kind }}MulticlusterReconciler struct {

--- a/codegen/templates/code/controller/reconcilers.gotmpl
+++ b/codegen/templates/code/controller/reconcilers.gotmpl
@@ -77,7 +77,8 @@ type {{ $kindLowerCamel }}ReconcileLoop struct {
 
 func New{{ $resource.Kind }}ReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) {{ $resource.Kind }}ReconcileLoop {
     return &{{ $kindLowerCamel }}ReconcileLoop{
-        loop: reconcile.NewLoop(name, mgr, &{{ $import_prefix }}.{{ $resource.Kind }}{}, options),
+    	// empty cluster indicates this reconciler is built for the local cluster
+        loop: reconcile.NewLoop(name, "", mgr, &{{ $import_prefix }}.{{ $resource.Kind }}{}, options),
     }
 }
 

--- a/codegen/test/api/things.test.io/v1/controller/multicluster_reconcilers.go
+++ b/codegen/test/api/things.test.io/v1/controller/multicluster_reconcilers.go
@@ -66,8 +66,8 @@ func (m *multiclusterPaintReconcileLoop) AddMulticlusterPaintReconciler(ctx cont
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterPaintReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterPaintReconcileLoop {
-	return &multiclusterPaintReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &things_test_io_v1.Paint{})}
+func NewMulticlusterPaintReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterPaintReconcileLoop {
+	return &multiclusterPaintReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &things_test_io_v1.Paint{}, options)}
 }
 
 type genericPaintMulticlusterReconciler struct {
@@ -137,8 +137,8 @@ func (m *multiclusterClusterResourceReconcileLoop) AddMulticlusterClusterResourc
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterClusterResourceReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterClusterResourceReconcileLoop {
-	return &multiclusterClusterResourceReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &things_test_io_v1.ClusterResource{})}
+func NewMulticlusterClusterResourceReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterClusterResourceReconcileLoop {
+	return &multiclusterClusterResourceReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &things_test_io_v1.ClusterResource{}, options)}
 }
 
 type genericClusterResourceMulticlusterReconciler struct {

--- a/codegen/test/api/things.test.io/v1/controller/reconcilers.go
+++ b/codegen/test/api/things.test.io/v1/controller/reconcilers.go
@@ -74,7 +74,8 @@ type paintReconcileLoop struct {
 
 func NewPaintReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) PaintReconcileLoop {
 	return &paintReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &things_test_io_v1.Paint{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &things_test_io_v1.Paint{}, options),
 	}
 }
 
@@ -190,7 +191,8 @@ type clusterResourceReconcileLoop struct {
 
 func NewClusterResourceReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) ClusterResourceReconcileLoop {
 	return &clusterResourceReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &things_test_io_v1.ClusterResource{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &things_test_io_v1.ClusterResource{}, options),
 	}
 }
 

--- a/codegen/test/api/things.test.io/v1/zz_generated.deepcopy.go
+++ b/codegen/test/api/things.test.io/v1/zz_generated.deepcopy.go
@@ -14,8 +14,12 @@ func (in *Paint) DeepCopyInto(out *Paint) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+
+	// deepcopy spec
 	in.Spec.DeepCopyInto(&out.Spec)
+	// deepcopy status
 	in.Status.DeepCopyInto(&out.Status)
+
 	return
 }
 
@@ -71,7 +75,10 @@ func (in *ClusterResource) DeepCopyInto(out *ClusterResource) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+
+	// deepcopy spec
 	in.Spec.DeepCopyInto(&out.Spec)
+
 	return
 }
 

--- a/contrib/codegen/funcs/funcs.go
+++ b/contrib/codegen/funcs/funcs.go
@@ -26,6 +26,7 @@ func MakeTopLevelFuncs(outputFile string, selectFromGroups map[string][]model.Gr
 	groupImports := map[schema.GroupVersion]importedGroup{}
 
 	for _, grp := range importedGroups {
+		grp.Init()
 		groups = append(groups, grp.Group)
 		groupImports[grp.GroupVersion] = grp
 	}

--- a/contrib/codegen/templates/input/input_reconciler.gotmpl
+++ b/contrib/codegen/templates/input/input_reconciler.gotmpl
@@ -17,6 +17,8 @@ package {{ package }}
 import (
     "context"
 
+    "github.com/solo-io/skv2/pkg/verifier"
+
     "github.com/solo-io/skv2/contrib/pkg/input"
     sk_core_v1 "github.com/solo-io/skv2/pkg/api/core.skv2.solo.io/v1"
     "github.com/solo-io/skv2/pkg/multicluster"
@@ -57,6 +59,21 @@ type multiClusterReconcilerImpl struct {
     base input.MultiClusterReconciler
 }
 
+// Options for reconcileing a snapshot
+type ReconcileOptions struct {
+{{/* generate reconcile options here */}}
+{{- range $group := $groups }}
+{{ $client_import_prefix := group_import_name $group }}
+{{- range $resource := $group.Resources }}
+{{- $kindPlural := pluralize $resource.Kind }}
+{{- $kindLowerCamel := lower_camel $resource.Kind }}
+{{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
+    // Options for reconciling {{ $kindPlural }}
+    {{ $kindPlural }} reconcile.Options
+{{- end }}
+{{- end }}
+}
+
 // register the reconcile func with the cluster watcher
 // the reconcileInterval, if greater than 0, will limit the number of reconciles
 // to one per interval.
@@ -65,6 +82,7 @@ func RegisterMultiClusterReconciler(
         clusters multicluster.ClusterWatcher,
         reconcileFunc input.MultiClusterReconcileFunc,
         reconcileInterval time.Duration,
+        options ReconcileOptions,
         predicates ...predicate.Predicate,
 ) {
 
@@ -85,7 +103,10 @@ func RegisterMultiClusterReconciler(
 {{- $kindPlural := pluralize $resource.Kind }}
 {{- $kindLowerCamel := lower_camel $resource.Kind }}
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-    {{ $controller_import_prefix }}.NewMulticluster{{ $resource.Kind }}ReconcileLoop("{{ $resource.Kind }}", clusters).AddMulticluster{{ $resource.Kind }}Reconciler(ctx, r, predicates...)
+
+    {{ $controller_import_prefix }}.NewMulticluster{{ $resource.Kind }}ReconcileLoop("{{ $resource.Kind }}", clusters, options.{{ $kindPlural }}).AddMulticluster{{ $resource.Kind }}Reconciler(ctx, r, predicates...)
+
+
 {{- end }}
 {{- end }}
 
@@ -144,6 +165,7 @@ func RegisterSingleClusterReconciler(
         mgr manager.Manager,
         reconcileFunc input.SingleClusterReconcileFunc,
         reconcileInterval time.Duration,
+        options reconcile.Options,
         predicates ...predicate.Predicate,
 ) error {
 
@@ -164,7 +186,7 @@ func RegisterSingleClusterReconciler(
 {{- $kindPlural := pluralize $resource.Kind }}
 {{- $kindLowerCamel := lower_camel $resource.Kind }}
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-    if err := {{ $controller_import_prefix }}.New{{ $resource.Kind }}ReconcileLoop("{{ $resource.Kind }}", mgr, reconcile.Options{}).Run{{ $resource.Kind }}Reconciler(ctx, r, predicates...); err != nil {
+    if err := {{ $controller_import_prefix }}.New{{ $resource.Kind }}ReconcileLoop("{{ $resource.Kind }}", mgr, options).Run{{ $resource.Kind }}Reconciler(ctx, r, predicates...); err != nil {
     	return err
     }
 {{- end }}

--- a/contrib/codegen/templates/input/input_snapshot.gotmpl
+++ b/contrib/codegen/templates/input/input_snapshot.gotmpl
@@ -21,6 +21,19 @@ import (
     "context"
     "encoding/json"
 
+    "k8s.io/apimachinery/pkg/runtime/schema"
+    "github.com/solo-io/skv2/pkg/verifier"
+    "sigs.k8s.io/controller-runtime/pkg/manager"
+
+    "github.com/solo-io/go-utils/contextutils"
+    "k8s.io/apimachinery/pkg/api/errors"
+    "k8s.io/client-go/rest"
+    "k8s.io/client-go/discovery"
+
+    "github.com/rotisserie/eris"
+    "github.com/solo-io/skv2/pkg/ezkube"
+    apiextensions_k8s_io_v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
     "github.com/hashicorp/go-multierror"
     "github.com/solo-io/skv2/pkg/controllerutils"
     "github.com/solo-io/skv2/pkg/multicluster"
@@ -201,46 +214,37 @@ type BuildOptions struct {
 {{- $kindLowerCamel := lower_camel $resource.Kind }}
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
     // List options for composing a snapshot from {{ $kindPlural }}
-    {{ $kindPlural }} []client.ListOption
+    {{ $kindPlural }} ResourceBuildOptions
 {{- end }}
 {{- end }}
+}
+
+// Options for reading resources of a given type
+type ResourceBuildOptions struct {
+{{/* generate build options here */}}
+    // List options for composing a snapshot from a resource type
+    ListOptions []client.ListOption
+
+    // If provided, ensure the resource has been verified before adding it to snapshots
+    Verifier verifier.ServerResourceVerifier
 }
 
 // build a snapshot from resources across multiple clusters
 type multiClusterBuilder struct {
-    clusters     multicluster.ClusterSet
-{{/* generate client fields here */}}
-{{- range $group := $groups }}
-{{ $client_import_prefix := group_import_name $group }}
-{{- range $resource := $group.Resources }}
-{{- $kindPlural := pluralize $resource.Kind }}
-{{- $kindLowerCamel := lower_camel $resource.Kind }}
-{{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-    {{ $kindLowerCamelPlural }} {{ $client_import_prefix }}.Multicluster{{ $resource.Kind }}Client
-{{- end }}
-{{- end }}
+    clusters multicluster.Interface
+    client   multicluster.Client
 }
 
 // Produces snapshots of resources across all clusters defined in the ClusterSet
 func NewMultiClusterBuilder(
-        clusters multicluster.ClusterSet,
+        clusters multicluster.Interface,
         client multicluster.Client,
 ) Builder {
     return &multiClusterBuilder{
-        clusters:     clusters,
-{{/* generate constructor fields here */}}
-{{- range $group := $groups }}
-{{ $client_import_prefix := group_import_name $group }}
-{{- range $resource := $group.Resources }}
-{{- $kindPlural := pluralize $resource.Kind }}
-{{- $kindLowerCamel := lower_camel $resource.Kind }}
-{{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-    {{ $kindLowerCamelPlural }}: {{ $client_import_prefix }}.NewMulticluster{{ $resource.Kind }}Client(client),
-{{- end }}
-{{- end }}
+        clusters: clusters,
+        client:   client,
     }
 }
-
 
 func (b *multiClusterBuilder) BuildSnapshot(ctx context.Context, name string, opts BuildOptions) (Snapshot, error) {
 {{/* generate set initialization here */}}
@@ -264,7 +268,7 @@ func (b *multiClusterBuilder) BuildSnapshot(ctx context.Context, name string, op
 {{- $kindPlural := pluralize $resource.Kind }}
 {{- $kindLowerCamel := lower_camel $resource.Kind }}
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-        if err := b.insert{{ $kindPlural }}FromCluster(ctx, cluster, {{ $kindLowerCamelPlural }}, opts.{{ $kindPlural }}...); err != nil {
+        if err := b.insert{{ $kindPlural }}FromCluster(ctx, cluster, {{ $kindLowerCamelPlural }}, opts.{{ $kindPlural }}); err != nil {
             errs = multierror.Append(errs, err)
         }
 {{- end }}
@@ -289,18 +293,42 @@ func (b *multiClusterBuilder) BuildSnapshot(ctx context.Context, name string, op
 
 {{/* generate insertion funcs here */}}
 {{- range $group := $groups }}
+{{ $client_import_prefix := group_import_name $group }}
 {{ $set_import_prefix := printf "%v_sets" (group_import_name $group) }}
 {{- range $resource := $group.Resources }}
 {{- $kindPlural := pluralize $resource.Kind }}
 {{- $kindLowerCamel := lower_camel $resource.Kind }}
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-func (b *multiClusterBuilder) insert{{ $kindPlural }}FromCluster(ctx context.Context, cluster string, {{ $kindLowerCamelPlural }} {{ $set_import_prefix }}.{{ $resource.Kind }}Set, opts ...client.ListOption) error {
-    {{ $kindLowerCamel }}Client, err := b.{{ $kindLowerCamelPlural }}.Cluster(cluster)
+func (b *multiClusterBuilder) insert{{ $kindPlural }}FromCluster(ctx context.Context, cluster string, {{ $kindLowerCamelPlural }} {{ $set_import_prefix }}.{{ $resource.Kind }}Set, opts ResourceBuildOptions) error {
+    {{ $kindLowerCamel }}Client, err := {{ $client_import_prefix }}.NewMulticluster{{ $resource.Kind }}Client(b.client).Cluster(cluster)
     if err != nil {
         return err
     }
 
-    {{ $kindLowerCamel }}List, err := {{ $kindLowerCamel }}Client.List{{ $resource.Kind }}(ctx, opts...)
+    if opts.Verifier != nil {
+    	mgr, err := b.clusters.Cluster(cluster)
+    	if err != nil {
+    		return err
+        }
+
+        gvk := schema.GroupVersionKind{
+            Group:   "{{ $resource.Group.Group }}",
+            Version: "{{ $resource.Group.Version }}",
+            Kind:    "{{ $resource.Kind }}",
+        }
+
+        if resourceRegistered, err := opts.Verifier.VerifyServerResource(
+        	cluster,
+        	mgr.GetConfig(),
+        	gvk,
+        ); err != nil{
+            return err
+        } else if !resourceRegistered {
+            return nil
+        }
+    }
+
+    {{ $kindLowerCamel }}List, err := {{ $kindLowerCamel }}Client.List{{ $resource.Kind }}(ctx, opts.ListOptions...)
     if err != nil {
         return err
     }
@@ -320,33 +348,15 @@ func (b *multiClusterBuilder) insert{{ $kindPlural }}FromCluster(ctx context.Con
 
 // build a snapshot from resources in a single cluster
 type singleClusterBuilder struct {
-{{/* generate client fields here */}}
-{{- range $group := $groups }}
-{{ $client_import_prefix := group_import_name $group }}
-{{- range $resource := $group.Resources }}
-{{- $kindPlural := pluralize $resource.Kind }}
-{{- $kindLowerCamel := lower_camel $resource.Kind }}
-{{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-    {{ $kindLowerCamelPlural }} {{ $client_import_prefix }}.{{ $resource.Kind }}Client
-{{- end }}
-{{- end }}
+    mgr manager.Manager
 }
 
 // Produces snapshots of resources across all clusters defined in the ClusterSet
 func NewSingleClusterBuilder(
-        client client.Client,
+        mgr manager.Manager,
 ) Builder {
     return &singleClusterBuilder{
-{{/* generate constructor fields here */}}
-{{- range $group := $groups }}
-{{ $client_import_prefix := group_import_name $group }}
-{{- range $resource := $group.Resources }}
-{{- $kindPlural := pluralize $resource.Kind }}
-{{- $kindLowerCamel := lower_camel $resource.Kind }}
-{{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-    {{ $kindLowerCamelPlural }}: {{ $client_import_prefix }}.New{{ $resource.Kind }}Client(client),
-{{- end }}
-{{- end }}
+        mgr: mgr,
     }
 }
 
@@ -371,7 +381,7 @@ func (b *singleClusterBuilder) BuildSnapshot(ctx context.Context, name string, o
 {{- $kindPlural := pluralize $resource.Kind }}
 {{- $kindLowerCamel := lower_camel $resource.Kind }}
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-    if err := b.insert{{ $kindPlural }}(ctx,  {{ $kindLowerCamelPlural }}, opts.{{ $kindPlural }}...); err != nil {
+    if err := b.insert{{ $kindPlural }}(ctx,  {{ $kindLowerCamelPlural }}, opts.{{ $kindPlural }}); err != nil {
         errs = multierror.Append(errs, err)
     }
 {{- end }}
@@ -395,12 +405,32 @@ func (b *singleClusterBuilder) BuildSnapshot(ctx context.Context, name string, o
 {{/* generate insertion funcs here */}}
 {{- range $group := $groups }}
 {{ $set_import_prefix := printf "%v_sets" (group_import_name $group) }}
+{{ $client_import_prefix := group_import_name $group }}
 {{- range $resource := $group.Resources }}
 {{- $kindPlural := pluralize $resource.Kind }}
 {{- $kindLowerCamel := lower_camel $resource.Kind }}
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-func (b *singleClusterBuilder) insert{{ $kindPlural }}(ctx context.Context, {{ $kindLowerCamelPlural }} {{ $set_import_prefix }}.{{ $resource.Kind }}Set, opts ...client.ListOption) error {
-    {{ $kindLowerCamel }}List, err := b.{{ $kindLowerCamelPlural }}.List{{ $resource.Kind }}(ctx, opts...)
+func (b *singleClusterBuilder) insert{{ $kindPlural }}(ctx context.Context, {{ $kindLowerCamelPlural }} {{ $set_import_prefix }}.{{ $resource.Kind }}Set, opts ResourceBuildOptions) error {
+
+    if opts.Verifier != nil {
+        gvk := schema.GroupVersionKind{
+            Group:   "{{ $resource.Group.Group }}",
+            Version: "{{ $resource.Group.Version }}",
+            Kind:    "{{ $resource.Kind }}",
+        }
+
+        if resourceRegistered, err := opts.Verifier.VerifyServerResource(
+            "", // verify in the local cluster
+            b.mgr.GetConfig(),
+            gvk,
+        ); err != nil{
+            return err
+        } else if !resourceRegistered {
+            return nil
+        }
+    }
+
+    {{ $kindLowerCamel }}List, err := {{ $client_import_prefix }}.New{{ $resource.Kind }}Client(b.mgr.GetClient()).List{{ $resource.Kind }}(ctx, opts.ListOptions...)
     if err != nil {
         return err
     }

--- a/pkg/api/multicluster.solo.io/v1alpha1/controller/multicluster_reconcilers.go
+++ b/pkg/api/multicluster.solo.io/v1alpha1/controller/multicluster_reconcilers.go
@@ -66,8 +66,8 @@ func (m *multiclusterKubernetesClusterReconcileLoop) AddMulticlusterKubernetesCl
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterKubernetesClusterReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterKubernetesClusterReconcileLoop {
-	return &multiclusterKubernetesClusterReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &multicluster_solo_io_v1alpha1.KubernetesCluster{})}
+func NewMulticlusterKubernetesClusterReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterKubernetesClusterReconcileLoop {
+	return &multiclusterKubernetesClusterReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &multicluster_solo_io_v1alpha1.KubernetesCluster{}, options)}
 }
 
 type genericKubernetesClusterMulticlusterReconciler struct {

--- a/pkg/api/multicluster.solo.io/v1alpha1/controller/reconcilers.go
+++ b/pkg/api/multicluster.solo.io/v1alpha1/controller/reconcilers.go
@@ -74,7 +74,8 @@ type kubernetesClusterReconcileLoop struct {
 
 func NewKubernetesClusterReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) KubernetesClusterReconcileLoop {
 	return &kubernetesClusterReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &multicluster_solo_io_v1alpha1.KubernetesCluster{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &multicluster_solo_io_v1alpha1.KubernetesCluster{}, options),
 	}
 }
 

--- a/pkg/multicluster/internal/k8s/admissionregistration.k8s.io/v1/controller/multicluster_reconcilers.go
+++ b/pkg/multicluster/internal/k8s/admissionregistration.k8s.io/v1/controller/multicluster_reconcilers.go
@@ -66,8 +66,8 @@ func (m *multiclusterValidatingWebhookConfigurationReconcileLoop) AddMulticluste
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterValidatingWebhookConfigurationReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterValidatingWebhookConfigurationReconcileLoop {
-	return &multiclusterValidatingWebhookConfigurationReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &admissionregistration_k8s_io_v1.ValidatingWebhookConfiguration{})}
+func NewMulticlusterValidatingWebhookConfigurationReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterValidatingWebhookConfigurationReconcileLoop {
+	return &multiclusterValidatingWebhookConfigurationReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &admissionregistration_k8s_io_v1.ValidatingWebhookConfiguration{}, options)}
 }
 
 type genericValidatingWebhookConfigurationMulticlusterReconciler struct {

--- a/pkg/multicluster/internal/k8s/admissionregistration.k8s.io/v1/controller/reconcilers.go
+++ b/pkg/multicluster/internal/k8s/admissionregistration.k8s.io/v1/controller/reconcilers.go
@@ -74,7 +74,8 @@ type validatingWebhookConfigurationReconcileLoop struct {
 
 func NewValidatingWebhookConfigurationReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) ValidatingWebhookConfigurationReconcileLoop {
 	return &validatingWebhookConfigurationReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &admissionregistration_k8s_io_v1.ValidatingWebhookConfiguration{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &admissionregistration_k8s_io_v1.ValidatingWebhookConfiguration{}, options),
 	}
 }
 

--- a/pkg/multicluster/internal/k8s/apiextensions.k8s.io/v1beta1/controller/multicluster_reconcilers.go
+++ b/pkg/multicluster/internal/k8s/apiextensions.k8s.io/v1beta1/controller/multicluster_reconcilers.go
@@ -66,8 +66,8 @@ func (m *multiclusterCustomResourceDefinitionReconcileLoop) AddMulticlusterCusto
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterCustomResourceDefinitionReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterCustomResourceDefinitionReconcileLoop {
-	return &multiclusterCustomResourceDefinitionReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &apiextensions_k8s_io_v1beta1.CustomResourceDefinition{})}
+func NewMulticlusterCustomResourceDefinitionReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterCustomResourceDefinitionReconcileLoop {
+	return &multiclusterCustomResourceDefinitionReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &apiextensions_k8s_io_v1beta1.CustomResourceDefinition{}, options)}
 }
 
 type genericCustomResourceDefinitionMulticlusterReconciler struct {

--- a/pkg/multicluster/internal/k8s/apiextensions.k8s.io/v1beta1/controller/reconcilers.go
+++ b/pkg/multicluster/internal/k8s/apiextensions.k8s.io/v1beta1/controller/reconcilers.go
@@ -74,7 +74,8 @@ type customResourceDefinitionReconcileLoop struct {
 
 func NewCustomResourceDefinitionReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) CustomResourceDefinitionReconcileLoop {
 	return &customResourceDefinitionReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &apiextensions_k8s_io_v1beta1.CustomResourceDefinition{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &apiextensions_k8s_io_v1beta1.CustomResourceDefinition{}, options),
 	}
 }
 

--- a/pkg/multicluster/internal/k8s/certificates.k8s.io/v1beta1/controller/multicluster_reconcilers.go
+++ b/pkg/multicluster/internal/k8s/certificates.k8s.io/v1beta1/controller/multicluster_reconcilers.go
@@ -66,8 +66,8 @@ func (m *multiclusterCertificateSigningRequestReconcileLoop) AddMulticlusterCert
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterCertificateSigningRequestReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterCertificateSigningRequestReconcileLoop {
-	return &multiclusterCertificateSigningRequestReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &certificates_k8s_io_v1beta1.CertificateSigningRequest{})}
+func NewMulticlusterCertificateSigningRequestReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterCertificateSigningRequestReconcileLoop {
+	return &multiclusterCertificateSigningRequestReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &certificates_k8s_io_v1beta1.CertificateSigningRequest{}, options)}
 }
 
 type genericCertificateSigningRequestMulticlusterReconciler struct {

--- a/pkg/multicluster/internal/k8s/certificates.k8s.io/v1beta1/controller/reconcilers.go
+++ b/pkg/multicluster/internal/k8s/certificates.k8s.io/v1beta1/controller/reconcilers.go
@@ -74,7 +74,8 @@ type certificateSigningRequestReconcileLoop struct {
 
 func NewCertificateSigningRequestReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) CertificateSigningRequestReconcileLoop {
 	return &certificateSigningRequestReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &certificates_k8s_io_v1beta1.CertificateSigningRequest{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &certificates_k8s_io_v1beta1.CertificateSigningRequest{}, options),
 	}
 }
 

--- a/pkg/multicluster/internal/k8s/core/v1/controller/multicluster_reconcilers.go
+++ b/pkg/multicluster/internal/k8s/core/v1/controller/multicluster_reconcilers.go
@@ -66,8 +66,8 @@ func (m *multiclusterSecretReconcileLoop) AddMulticlusterSecretReconciler(ctx co
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterSecretReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterSecretReconcileLoop {
-	return &multiclusterSecretReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &v1.Secret{})}
+func NewMulticlusterSecretReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterSecretReconcileLoop {
+	return &multiclusterSecretReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &v1.Secret{}, options)}
 }
 
 type genericSecretMulticlusterReconciler struct {
@@ -137,8 +137,8 @@ func (m *multiclusterServiceAccountReconcileLoop) AddMulticlusterServiceAccountR
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterServiceAccountReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterServiceAccountReconcileLoop {
-	return &multiclusterServiceAccountReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &v1.ServiceAccount{})}
+func NewMulticlusterServiceAccountReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterServiceAccountReconcileLoop {
+	return &multiclusterServiceAccountReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &v1.ServiceAccount{}, options)}
 }
 
 type genericServiceAccountMulticlusterReconciler struct {
@@ -208,8 +208,8 @@ func (m *multiclusterNamespaceReconcileLoop) AddMulticlusterNamespaceReconciler(
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterNamespaceReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterNamespaceReconcileLoop {
-	return &multiclusterNamespaceReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &v1.Namespace{})}
+func NewMulticlusterNamespaceReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterNamespaceReconcileLoop {
+	return &multiclusterNamespaceReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &v1.Namespace{}, options)}
 }
 
 type genericNamespaceMulticlusterReconciler struct {

--- a/pkg/multicluster/internal/k8s/core/v1/controller/reconcilers.go
+++ b/pkg/multicluster/internal/k8s/core/v1/controller/reconcilers.go
@@ -74,7 +74,8 @@ type secretReconcileLoop struct {
 
 func NewSecretReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) SecretReconcileLoop {
 	return &secretReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &v1.Secret{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &v1.Secret{}, options),
 	}
 }
 
@@ -190,7 +191,8 @@ type serviceAccountReconcileLoop struct {
 
 func NewServiceAccountReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) ServiceAccountReconcileLoop {
 	return &serviceAccountReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &v1.ServiceAccount{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &v1.ServiceAccount{}, options),
 	}
 }
 
@@ -306,7 +308,8 @@ type namespaceReconcileLoop struct {
 
 func NewNamespaceReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) NamespaceReconcileLoop {
 	return &namespaceReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &v1.Namespace{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &v1.Namespace{}, options),
 	}
 }
 

--- a/pkg/multicluster/internal/k8s/rbac.authorization.k8s.io/v1/controller/multicluster_reconcilers.go
+++ b/pkg/multicluster/internal/k8s/rbac.authorization.k8s.io/v1/controller/multicluster_reconcilers.go
@@ -66,8 +66,8 @@ func (m *multiclusterRoleReconcileLoop) AddMulticlusterRoleReconciler(ctx contex
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterRoleReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterRoleReconcileLoop {
-	return &multiclusterRoleReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &rbac_authorization_k8s_io_v1.Role{})}
+func NewMulticlusterRoleReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterRoleReconcileLoop {
+	return &multiclusterRoleReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &rbac_authorization_k8s_io_v1.Role{}, options)}
 }
 
 type genericRoleMulticlusterReconciler struct {
@@ -137,8 +137,8 @@ func (m *multiclusterRoleBindingReconcileLoop) AddMulticlusterRoleBindingReconci
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterRoleBindingReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterRoleBindingReconcileLoop {
-	return &multiclusterRoleBindingReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &rbac_authorization_k8s_io_v1.RoleBinding{})}
+func NewMulticlusterRoleBindingReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterRoleBindingReconcileLoop {
+	return &multiclusterRoleBindingReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &rbac_authorization_k8s_io_v1.RoleBinding{}, options)}
 }
 
 type genericRoleBindingMulticlusterReconciler struct {
@@ -208,8 +208,8 @@ func (m *multiclusterClusterRoleReconcileLoop) AddMulticlusterClusterRoleReconci
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterClusterRoleReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterClusterRoleReconcileLoop {
-	return &multiclusterClusterRoleReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &rbac_authorization_k8s_io_v1.ClusterRole{})}
+func NewMulticlusterClusterRoleReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterClusterRoleReconcileLoop {
+	return &multiclusterClusterRoleReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &rbac_authorization_k8s_io_v1.ClusterRole{}, options)}
 }
 
 type genericClusterRoleMulticlusterReconciler struct {
@@ -279,8 +279,8 @@ func (m *multiclusterClusterRoleBindingReconcileLoop) AddMulticlusterClusterRole
 	m.loop.AddReconciler(ctx, genericReconciler, predicates...)
 }
 
-func NewMulticlusterClusterRoleBindingReconcileLoop(name string, cw multicluster.ClusterWatcher) MulticlusterClusterRoleBindingReconcileLoop {
-	return &multiclusterClusterRoleBindingReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &rbac_authorization_k8s_io_v1.ClusterRoleBinding{})}
+func NewMulticlusterClusterRoleBindingReconcileLoop(name string, cw multicluster.ClusterWatcher, options reconcile.Options) MulticlusterClusterRoleBindingReconcileLoop {
+	return &multiclusterClusterRoleBindingReconcileLoop{loop: mc_reconcile.NewLoop(name, cw, &rbac_authorization_k8s_io_v1.ClusterRoleBinding{}, options)}
 }
 
 type genericClusterRoleBindingMulticlusterReconciler struct {

--- a/pkg/multicluster/internal/k8s/rbac.authorization.k8s.io/v1/controller/reconcilers.go
+++ b/pkg/multicluster/internal/k8s/rbac.authorization.k8s.io/v1/controller/reconcilers.go
@@ -74,7 +74,8 @@ type roleReconcileLoop struct {
 
 func NewRoleReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) RoleReconcileLoop {
 	return &roleReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &rbac_authorization_k8s_io_v1.Role{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &rbac_authorization_k8s_io_v1.Role{}, options),
 	}
 }
 
@@ -190,7 +191,8 @@ type roleBindingReconcileLoop struct {
 
 func NewRoleBindingReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) RoleBindingReconcileLoop {
 	return &roleBindingReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &rbac_authorization_k8s_io_v1.RoleBinding{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &rbac_authorization_k8s_io_v1.RoleBinding{}, options),
 	}
 }
 
@@ -306,7 +308,8 @@ type clusterRoleReconcileLoop struct {
 
 func NewClusterRoleReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) ClusterRoleReconcileLoop {
 	return &clusterRoleReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &rbac_authorization_k8s_io_v1.ClusterRole{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &rbac_authorization_k8s_io_v1.ClusterRole{}, options),
 	}
 }
 
@@ -422,7 +425,8 @@ type clusterRoleBindingReconcileLoop struct {
 
 func NewClusterRoleBindingReconcileLoop(name string, mgr manager.Manager, options reconcile.Options) ClusterRoleBindingReconcileLoop {
 	return &clusterRoleBindingReconcileLoop{
-		loop: reconcile.NewLoop(name, mgr, &rbac_authorization_k8s_io_v1.ClusterRoleBinding{}, options),
+		// empty cluster indicates this reconciler is built for the local cluster
+		loop: reconcile.NewLoop(name, "", mgr, &rbac_authorization_k8s_io_v1.ClusterRoleBinding{}, options),
 	}
 }
 

--- a/pkg/multicluster/reconcile/reconcile.go
+++ b/pkg/multicluster/reconcile/reconcile.go
@@ -19,18 +19,20 @@ type clusterLoopRunner struct {
 	resource     ezkube.Object
 	clusterLoops *clusterLoopSet
 	reconcilers  *reconcilerList
+	options      reconcile.Options
 }
 
 var _ multicluster.Loop = &clusterLoopRunner{}
 var _ multicluster.ClusterHandler = &clusterLoopRunner{}
 var _ multicluster.ClusterRemovedHandler = &clusterLoopRunner{}
 
-func NewLoop(name string, cw multicluster.ClusterWatcher, resource ezkube.Object) *clusterLoopRunner {
+func NewLoop(name string, cw multicluster.ClusterWatcher, resource ezkube.Object, options reconcile.Options) *clusterLoopRunner {
 	runner := &clusterLoopRunner{
 		name:         name,
 		resource:     resource,
 		clusterLoops: newClusterLoopSet(),
 		reconcilers:  newReconcilerList(),
+		options:      options,
 	}
 	cw.RegisterClusterHandler(runner)
 
@@ -39,7 +41,7 @@ func NewLoop(name string, cw multicluster.ClusterWatcher, resource ezkube.Object
 
 // AddCluster creates a reconcile loop for the cluster.
 func (r *clusterLoopRunner) AddCluster(ctx context.Context, cluster string, mgr manager.Manager) {
-	loopForCluster := reconcile.NewLoop(r.name+"-"+cluster, mgr, r.resource, reconcile.Options{})
+	loopForCluster := reconcile.NewLoop(r.name+"-"+cluster, cluster, mgr, r.resource, r.options)
 
 	// Add the cluster loop to the set of active loops and start reconcilers.
 	r.clusterLoops.add(cluster, loopForCluster)

--- a/pkg/multicluster/watch/watcher.go
+++ b/pkg/multicluster/watch/watcher.go
@@ -23,9 +23,7 @@ type clusterWatcher struct {
 	options  manager.Options
 }
 
-var _ multicluster.ClusterWatcher = &clusterWatcher{}
-var _ multicluster.ManagerSet = &clusterWatcher{}
-var _ multicluster.ClusterSet = &clusterWatcher{}
+var _ multicluster.Interface = &clusterWatcher{}
 
 // NewClusterWatcher returns a *clusterWatcher.
 // When ctx is cancelled, all cluster managers started by the clusterWatcher are stopped.
@@ -96,7 +94,7 @@ func (c *clusterWatcher) startManager(clusterName string, mgr manager.Manager) {
 	go func() {
 		err := mgr.Start(ctx.Done())
 		if err != nil {
-			contextutils.LoggerFrom(ctx).DPanicw("manager start failed for cluster %v", clusterName)
+			contextutils.LoggerFrom(ctx).DPanicf("manager start failed for cluster %v: %v", clusterName, err)
 		}
 	}()
 

--- a/pkg/multicluster/watcher.go
+++ b/pkg/multicluster/watcher.go
@@ -28,3 +28,10 @@ type ClusterSet interface {
 	// List the clusters (sorted) currently known to the set
 	ListClusters() []string
 }
+
+// the multicluster Interface provides a handle to interacting with multiple clusters.
+// the multicluster watcher implements this interface.
+type Interface interface {
+	ClusterWatcher
+	ManagerSet
+}

--- a/pkg/verifier/verifier.go
+++ b/pkg/verifier/verifier.go
@@ -1,0 +1,147 @@
+package verifier
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/go-utils/contextutils"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+)
+
+// ServerVerifyOption is used to specify one of several options on
+// whether and how to verify the resource's availabiltiy on the API server
+type ServerVerifyOption int
+
+const (
+	// skip verifying whether a resource is  for a kind before reading it from the API server
+	ServerVerifyOption_SkipVerify ServerVerifyOption = iota
+
+	// return an error if the resource does not exist for a kind before reading it from the API server
+	ServerVerifyOption_ErrorIfNotPresent
+
+	// log an error (and continue) if the resource does not exist for a kind before reading it from the API server
+	// the reconcile loop will not be started if the server resource is not supported.
+	ServerVerifyOption_WarnIfNotPresent
+
+	// ignore error (and continue) if the resource does not exist for a kind before reading it from the API server.
+	// the reconcile loop will not be started if the server resource is not supported.
+	ServerVerifyOption_IgnoreIfNotPresent
+)
+
+// ServerResourceVerifier verifies whether a given cluster server supports a given resource.
+type ServerResourceVerifier interface {
+	// Verify whether the API server for the given rest.Config supports the resource with the given GVK.
+	// For the "local/management" cluster, set cluster to ""
+	// Note that once a resource has been verified, the result will be cached for subsequent calls.
+	// Returns true if the resource is registered, false otherwise.
+	// an error will be returned if the ErrorIfNotPresent option is selected for the given GVK
+	VerifyServerResource(cluster string, cfg *rest.Config, gvk schema.GroupVersionKind) (bool, error)
+}
+
+type verifier struct {
+	// used for logging
+	ctx context.Context
+
+	// set of per-resource-type verify options; default is Skip.
+	options map[schema.GroupVersionKind]ServerVerifyOption
+
+	// set when a resource is successfully verified for the first time.
+	// future calls to VerifyServerResource will return quickly if the
+	// resources have already been verified for the cluster.
+	verifiedClusterResources map[string]map[schema.GroupVersionKind]bool
+	lock                     sync.RWMutex
+}
+
+func NewVerifier(
+	ctx context.Context,
+	options map[schema.GroupVersionKind]ServerVerifyOption,
+) *verifier {
+	if options == nil {
+		options = map[schema.GroupVersionKind]ServerVerifyOption{}
+	}
+	return &verifier{
+		ctx:                      ctx,
+		options:                  options,
+		verifiedClusterResources: map[string]map[schema.GroupVersionKind]bool{},
+	}
+}
+
+// Verify whether the API server for the given rest.Config supports the resource with the given GVK.
+func (v *verifier) VerifyServerResource(cluster string, cfg *rest.Config, gvk schema.GroupVersionKind) (bool, error) {
+	v.lock.RLock()
+	verifiedResources, ok := v.verifiedClusterResources[cluster]
+	if ok {
+		resourceRegistered, resourceHasBeenVerified := verifiedResources[gvk]
+		if resourceHasBeenVerified {
+			// exit early if the resource has already been verified
+			v.lock.RUnlock()
+			return resourceRegistered, nil
+		}
+	} else {
+		verifiedResources = map[schema.GroupVersionKind]bool{}
+	}
+
+	// get option for this gvk
+	// defaults to skip
+	verifyOption := v.options[gvk]
+	v.lock.RUnlock()
+
+	if verifyOption == ServerVerifyOption_SkipVerify {
+		return true, nil
+	}
+
+	var resourceRegistered bool
+	if verifyFailed, err := verifyServerResource(cfg, gvk); err != nil {
+		if verifyFailed {
+			return false, eris.Wrap(err, "resource verify failed")
+		}
+
+		switch verifyOption {
+		case ServerVerifyOption_ErrorIfNotPresent:
+			return false, err
+		case ServerVerifyOption_WarnIfNotPresent:
+			contextutils.LoggerFrom(v.ctx).Warnf("%v not registered (fetch err: %v)", gvk, err)
+			fallthrough
+		case ServerVerifyOption_IgnoreIfNotPresent:
+			resourceRegistered = false
+		}
+	} else {
+		resourceRegistered = true
+	}
+
+	// update cache
+	v.lock.Lock()
+	verifiedResources[gvk] = resourceRegistered
+	v.verifiedClusterResources[cluster] = verifiedResources
+	v.lock.Unlock()
+
+	return resourceRegistered, nil
+}
+
+// The boolean return return argument indicates whether a resulting error was caused by
+// a failure to run the verification verify.
+func verifyServerResource(
+	cfg *rest.Config,
+	gvk schema.GroupVersionKind,
+) (bool, error) {
+	disc, err := discovery.NewDiscoveryClientForConfig(cfg)
+	if err != nil {
+		return true, err
+	}
+	rss, err := disc.ServerResourcesForGroupVersion(gvk.Group + "/" + gvk.Version)
+	if err != nil {
+		verifyFailed := !apierrors.IsNotFound(err)
+		return verifyFailed, err
+	}
+	for _, resource := range rss.APIResources {
+		if resource.Kind == gvk.Kind {
+			// success
+			return false, nil
+		}
+	}
+	return false, eris.Errorf("resource %v not supported by API Server", gvk.String())
+}

--- a/pkg/verifier/verifier_suite_test.go
+++ b/pkg/verifier/verifier_suite_test.go
@@ -1,0 +1,13 @@
+package verifier_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestVerifier(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Verifier Suite")
+}

--- a/pkg/verifier/verifier_test.go
+++ b/pkg/verifier/verifier_test.go
@@ -1,0 +1,52 @@
+package verifier_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	. "github.com/solo-io/skv2/pkg/verifier"
+)
+
+var _ = Describe("Verifier", func() {
+	It("verifies the server resources", func() {
+		cfg, err := config.GetConfig()
+		if err != nil {
+			Skip("skipping verifier test, requires active kubernetes cluster, failed to get rest config: " + err.Error())
+		}
+
+		gvkDoesntExist := schema.GroupVersionKind{
+			Group:   "doesnt",
+			Version: "v1",
+			Kind:    "Exist",
+		}
+		gvkDoesExist := schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Secret",
+		}
+
+		v := NewVerifier(context.TODO(), map[schema.GroupVersionKind]ServerVerifyOption{
+			gvkDoesntExist: ServerVerifyOption_ErrorIfNotPresent,
+		})
+
+		resourceExists, err := v.VerifyServerResource("", cfg, gvkDoesntExist)
+		Expect(err).To(HaveOccurred())
+
+		resourceExists, err = v.VerifyServerResource("", cfg, gvkDoesExist)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resourceExists).To(BeTrue())
+
+		// ignore errors on doesn't exist
+		v = NewVerifier(context.TODO(), map[schema.GroupVersionKind]ServerVerifyOption{
+			gvkDoesntExist: ServerVerifyOption_WarnIfNotPresent,
+		})
+
+		resourceExists, err = v.VerifyServerResource("", cfg, gvkDoesntExist)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resourceExists).To(BeFalse())
+	})
+})


### PR DESCRIPTION
exposes an option to verify the existence of a CRD before attempting to read its instances from a cluster.

note: requires that the CRD type is registered to the scheme used by the provided `client`
BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/140