### PR TITLE
Nil kubeconfigs

### DIFF
--- a/changelog/v0.15.2/nil-kubeconfigs.yaml
+++ b/changelog/v0.15.2/nil-kubeconfigs.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: NON_USER_FACING
+  description: >
+    Error on nil kubeconfigs when registering clusters. When registering clusters, we now create
+    the KubernetesCluster CRD on the management cluster, which requires us to have the management
+    cluster's kube config passed in to the registration options.
+  issueLink: https://github.com/solo-io/skv2/issues/184

--- a/changelog/v0.15.2/nil-kubeconfigs.yaml
+++ b/changelog/v0.15.2/nil-kubeconfigs.yaml
@@ -5,3 +5,7 @@ changelog:
     the KubernetesCluster CRD on the management cluster, which requires us to have the management
     cluster's kube config passed in to the registration options.
   issueLink: https://github.com/solo-io/skv2/issues/184
+- type: NON_USER_FACING
+  description: >
+    Make SnapshotTemplateParameters ConstructTemplate function public.
+  issueLink: https://github.com/solo-io/skv2/issues/184

--- a/contrib/custom_top_level_templates.go
+++ b/contrib/custom_top_level_templates.go
@@ -76,7 +76,8 @@ func (r HybridSnapshotResources) makeTemplateFuncs(snapshotName, outputFilename 
 	)
 }
 
-func (p SnapshotTemplateParameters) constructTemplate(params SnapshotTemplateParameters, templatePath string) model.CustomTemplates {
+// NOTE(awang): to user your template in a separate repo, use this function and pass in your own templatePath
+func (p SnapshotTemplateParameters) ConstructTemplate(params SnapshotTemplateParameters, templatePath string) model.CustomTemplates {
 	templateContents, err := templatesBox.FindString(templatePath)
 	if err != nil {
 		panic(err)
@@ -102,7 +103,7 @@ const (
 
 // Returns the template for generating input snapshots.
 func InputSnapshot(params SnapshotTemplateParameters) model.CustomTemplates {
-	return params.constructTemplate(params, InputSnapshotCustomTemplatePath)
+	return params.ConstructTemplate(params, InputSnapshotCustomTemplatePath)
 }
 
 /*
@@ -114,7 +115,7 @@ const (
 
 // Returns the template for generating input snapshots.
 func InputSnapshotManualBuilder(params SnapshotTemplateParameters) model.CustomTemplates {
-	return params.constructTemplate(params, InputSnapshotManualBuilderCustomTemplatePath)
+	return params.ConstructTemplate(params, InputSnapshotManualBuilderCustomTemplatePath)
 }
 
 /*
@@ -131,7 +132,7 @@ func InputReconciler(params SnapshotTemplateParameters) model.CustomTemplates {
 	if _, isHybrid := params.SnapshotResources.(HybridSnapshotResources); isHybrid {
 		templatePath = HybridInputReconcilerCustomTemplatePath
 	}
-	return params.constructTemplate(params, templatePath)
+	return params.ConstructTemplate(params, templatePath)
 }
 
 /*
@@ -143,5 +144,5 @@ const (
 
 // Returns the template for generating output snapshots.
 func OutputSnapshot(params SnapshotTemplateParameters) model.CustomTemplates {
-	return params.constructTemplate(params, OutputSnapshotCustomTemplatePath)
+	return params.ConstructTemplate(params, OutputSnapshotCustomTemplatePath)
 }

--- a/pkg/multicluster/register/registrant.go
+++ b/pkg/multicluster/register/registrant.go
@@ -301,7 +301,7 @@ func (c *clusterRegistrant) DeleteRemoteAccessResources(ctx context.Context,
 
 func (c *clusterRegistrant) RegisterClusterWithToken(
 	ctx context.Context,
-	masterClusterCfg *rest.Config,
+	mgmtClusterCfg *rest.Config,
 	remoteClientCfg clientcmd.ClientConfig,
 	token string,
 	opts Options,
@@ -359,7 +359,7 @@ func (c *clusterRegistrant) RegisterClusterWithToken(
 		opts.RegistrationMetadata.ClusterRolePolicyRules,
 	)
 
-	kubeClusterClient, err := c.kubeClusterFactory(masterClusterCfg)
+	kubeClusterClient, err := c.kubeClusterFactory(mgmtClusterCfg)
 	if err != nil {
 		return err
 	}
@@ -372,7 +372,7 @@ func (c *clusterRegistrant) RegisterClusterWithToken(
 
 func (c *clusterRegistrant) DeregisterCluster(
 	ctx context.Context,
-	masterClusterCfg *rest.Config,
+	mgmtClusterCfg *rest.Config,
 	opts Options,
 ) error {
 	if err := (&opts).validate(); err != nil {
@@ -381,7 +381,7 @@ func (c *clusterRegistrant) DeregisterCluster(
 
 	kcSecretObjMeta := kubeconfig.SecretObjMeta(opts.Namespace, opts.ClusterName, nil)
 	kubeClusterObjMeta := kubeClusterObjMeta(kcSecretObjMeta.Name, kcSecretObjMeta.Namespace, nil)
-	kubeClusterClient, err := c.kubeClusterFactory(masterClusterCfg)
+	kubeClusterClient, err := c.kubeClusterFactory(mgmtClusterCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/multicluster/watcher.go
+++ b/pkg/multicluster/watcher.go
@@ -4,12 +4,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-// ClusterWatcher watches for KubeConfig secrets on the master cluster.
+// ClusterWatcher watches for KubeConfig secrets on the management cluster.
 // It is responsible for starting cluster managers and calling ClusterHandler functions.
 type ClusterWatcher interface {
 	// Run starts a watch for KubeConfig secrets on the cluster managed by the given manager.Manager.
 	// Note that Run will call Start on the given manager and run all registered ClusterHandlers.
-	Run(master manager.Manager) error
+	Run(management manager.Manager) error
 	// RegisterClusterHandler adds a ClusterHandler to the ClusterWatcher.
 	RegisterClusterHandler(handler ClusterHandler)
 }


### PR DESCRIPTION
In Gloo v1.6.0-beta16, we pulled in a skv2 dependency change from v0.8.1 to v0.13.5.

This change brings with it several changes to the way we register clusters (specifically for Gloo Fed). We now create the KubernetesCluster CRD on the management cluster, which requires us to have the mgmtKubeCfg passed into the registration options.

We should be consistent in calling the two clusters "management" and "remote".

We should now error when we attempt to register a cluster without passing in a KubeCfg or RemoteKubeCfg, instead of doing a segfault.

BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/184