### PR TITLE
make pointer to value if needed

### DIFF
--- a/changelog/v0.16.1/fix-equality.yaml
+++ b/changelog/v0.16.1/fix-equality.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: >
+      Fix the case where proto.Message types are passed in by value rather than by pointer.
+    issueLink: https://github.com/solo-io/skv2/issues/199

--- a/contrib/codegen/templates/input/input_reconciler.gotmpl
+++ b/contrib/codegen/templates/input/input_reconciler.gotmpl
@@ -56,7 +56,7 @@ type multiCluster{{ $snapshotName }}ReconcilerImpl struct {
     base input.InputReconciler
 }
 
-// Options for reconcileing a snapshot
+// Options for reconciling a snapshot
 type {{ $snapshotName }}ReconcileOptions struct {
 {{/* generate reconcile options here */}}
 {{- range $group := $groups }}

--- a/pkg/controllerutils/equality.go
+++ b/pkg/controllerutils/equality.go
@@ -63,7 +63,8 @@ func ObjectsEqual(obj1, obj2 runtime.Object) bool {
 
 // if i is a pointer, just return the value.
 // if i is addressable, return that.
-// Otherwise, make a new instance of the type and copy the contents to that and return it.
+// if i is a struct passed in by value, make a new instance of the type and copy the contents to that and return
+// the pointer to that.
 func mkPointer(i interface{}) interface{} {
 	val := reflect.ValueOf(i)
 	if val.Kind() == reflect.Ptr {
@@ -72,9 +73,12 @@ func mkPointer(i interface{}) interface{} {
 	if val.CanAddr() {
 		return val.Addr().Interface()
 	}
-	nv := reflect.New(reflect.TypeOf(i))
-	nv.Elem().Set(val)
-	return nv.Interface()
+	if val.Kind() == reflect.Struct {
+		nv := reflect.New(reflect.TypeOf(i))
+		nv.Elem().Set(val)
+		return nv.Interface()
+	}
+	return i
 }
 
 // returns true if "relevant" parts of obj1 and obj2 have equal:

--- a/pkg/controllerutils/equality.go
+++ b/pkg/controllerutils/equality.go
@@ -49,8 +49,8 @@ func ObjectsEqual(obj1, obj2 runtime.Object) bool {
 			continue
 		}
 
-		field1 := value1.Field(i).Interface()
-		field2 := value2.Field(i).Interface()
+		field1 := mkPointer(value1.Field(i).Interface())
+		field2 := mkPointer(value2.Field(i).Interface())
 
 		// assert DeepEquality any other fields
 		if !equalityutils.DeepEqual(field1, field2) {
@@ -59,6 +59,22 @@ func ObjectsEqual(obj1, obj2 runtime.Object) bool {
 	}
 
 	return true
+}
+
+// if i is a pointer, just return the value.
+// if i is addressable, return that.
+// Otherwise, make a new instance of the type and copy the contents to that and return it.
+func mkPointer(i interface{}) interface{} {
+	val := reflect.ValueOf(i)
+	if val.Kind() == reflect.Ptr {
+		return i
+	}
+	if val.CanAddr() {
+		return val.Addr().Interface()
+	}
+	nv := reflect.New(reflect.TypeOf(i))
+	nv.Elem().Set(val)
+	return nv.Interface()
 }
 
 // returns true if "relevant" parts of obj1 and obj2 have equal:

--- a/pkg/controllerutils/equality_test.go
+++ b/pkg/controllerutils/equality_test.go
@@ -81,6 +81,32 @@ var _ = Describe("ObjectsEqual", func() {
 		equal := ObjectsEqual(obj1, obj2)
 		Expect(equal).To(BeFalse())
 	})
+
+	It("asserts equality on two proto.Message objects even if they are passed in by value", func() {
+		obj1 := &things_test_io_v1.Paint{
+			Spec: things_test_io_v1.PaintSpec{
+				Color: &things_test_io_v1.PaintColor{
+					Hue: "red",
+				},
+				PaintType: &things_test_io_v1.PaintSpec_Oil{
+					Oil: nil,
+				},
+			},
+		}
+		obj1.Spec.ProtoReflect().SetUnknown([]byte(""))
+		obj2 := &things_test_io_v1.Paint{
+			Spec: things_test_io_v1.PaintSpec{
+				Color: &things_test_io_v1.PaintColor{
+					Hue: "red",
+				},
+				PaintType: &things_test_io_v1.PaintSpec_Oil{
+					Oil: nil,
+				},
+			},
+		}
+		equal := ObjectsEqual(obj1, obj2)
+		Expect(equal).To(BeTrue())
+	})
 })
 
 var _ = Describe("ObjectStatusesEqual", func() {


### PR DESCRIPTION
This is for the case where proto.Message types are passed in by value rather than by pointer.
For example:
```
var a interface{}
a = &fed_types.FailoverSchemeStatus{}
b, ok := a.(proto.Message) // ok == true, this will work
```
```
var a interface{}
a = fed_types.FailoverSchemeStatus{}
b, ok := a.(proto.Message) // ok == false, this will not work
```

The upgrade to using gogo/protobufs resulted in several changes around how protos are considered equal.

Previously, we made a change to fix this:
// DeepEqual should be used in place of reflect.DeepEqual when the type of an object is unknown and may be a proto message.
// see https://github.com/golang/protobuf/issues/1173 for details on why reflect.DeepEqual no longer works for proto messages

The way our reconcilers pass in objects into Upsert may result in these items being passed in by value
```
// in some cases:
type GlooInstance struct {
	state         protoimpl.MessageState
	sizeCache     protoimpl.SizeCache
	unknownFields protoimpl.UnknownFields

	Metadata *ObjectMeta               `protobuf:"bytes,1,opt,name=metadata,proto3" json:"metadata,omitempty"`
	Spec     *types.GlooInstanceSpec   `protobuf:"bytes,2,opt,name=spec,proto3" json:"spec,omitempty"`
	Status   *types.GlooInstanceStatus `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`
}

// In other cases:
// GlooInstance is the Schema for the glooInstance API
type GlooInstance struct {
	metav1.TypeMeta   `json:",inline"`
	metav1.ObjectMeta `json:"metadata,omitempty"`

	Spec   GlooInstanceSpec   `json:"spec,omitempty"`
	Status GlooInstanceStatus `json:"status,omitempty"`
}
```

Solution: be more flexible in the controllerutils.ObjectsEqual, and be able to deal with both cases.
See: https://github.com/gogo/protobuf/issues/476

BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/199