### PR TITLE
Fix skv2 equality

### DIFF
--- a/changelog/v0.17.2/fix-equality-segfault.yaml
+++ b/changelog/v0.17.2/fix-equality-segfault.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/skv2/issues/207
+    description: >-
+      Fix equality for protos, since we were using the `proto.Equals` on k8s resources that implemented the interface
+      but should have been using reflection.

--- a/pkg/controllerutils/equality_test.go
+++ b/pkg/controllerutils/equality_test.go
@@ -5,6 +5,7 @@ import (
 	. "github.com/onsi/gomega"
 	things_test_io_v1 "github.com/solo-io/skv2/codegen/test/api/things.test.io/v1"
 	v1 "k8s.io/api/core/v1"
+	rbac_authorization_k8s_io_v1 "k8s.io/api/rbac/v1"
 	k8s_meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	. "github.com/solo-io/skv2/pkg/controllerutils"
@@ -81,8 +82,7 @@ var _ = Describe("ObjectsEqual", func() {
 		equal := ObjectsEqual(obj1, obj2)
 		Expect(equal).To(BeFalse())
 	})
-
-	It("asserts equality on two proto.Message objects even if they are passed in by value", func() {
+	It("asserts equality on two proto.Message objects (protov2, with unknown fields) even if they are passed in by reference", func() {
 		obj1 := &things_test_io_v1.Paint{
 			Spec: things_test_io_v1.PaintSpec{
 				Color: &things_test_io_v1.PaintColor{
@@ -102,6 +102,46 @@ var _ = Describe("ObjectsEqual", func() {
 				PaintType: &things_test_io_v1.PaintSpec_Oil{
 					Oil: nil,
 				},
+			},
+		}
+		equal := ObjectsEqual(obj1, obj2)
+		Expect(equal).To(BeTrue())
+	})
+	It("asserts equality on two proto.Message objects even if they are 'fake' (i.e., k8s protos implementing github protov1, not google protov2 protos)", func() {
+		obj1 := &rbac_authorization_k8s_io_v1.RoleBinding{
+			TypeMeta: k8s_meta.TypeMeta{},
+			ObjectMeta: k8s_meta.ObjectMeta{
+				Name:      "sample-role-binding",
+				Namespace: "default",
+				Labels:    map[string]string{"k": "v"},
+			},
+			Subjects: []rbac_authorization_k8s_io_v1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      "sample-target",
+				Namespace: "default",
+			}},
+			RoleRef: rbac_authorization_k8s_io_v1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "sample-controller",
+			},
+		}
+		obj2 := &rbac_authorization_k8s_io_v1.RoleBinding{
+			TypeMeta: k8s_meta.TypeMeta{},
+			ObjectMeta: k8s_meta.ObjectMeta{
+				Name:      "sample-role-binding",
+				Namespace: "default",
+				Labels:    map[string]string{"k": "v"},
+			},
+			Subjects: []rbac_authorization_k8s_io_v1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      "sample-target",
+				Namespace: "default",
+			}},
+			RoleRef: rbac_authorization_k8s_io_v1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Role",
+				Name:     "sample-controller",
 			},
 		}
 		equal := ObjectsEqual(obj1, obj2)

--- a/pkg/equalityutils/deep_equal.go
+++ b/pkg/equalityutils/deep_equal.go
@@ -3,19 +3,19 @@ package equalityutils
 import (
 	"reflect"
 
-	"github.com/golang/protobuf/proto"
+	protoV2 "google.golang.org/protobuf/proto"
 )
 
 // DeepEqual should be used in place of reflect.DeepEqual when the type of an object is unknown and may be a proto message.
 // see https://github.com/golang/protobuf/issues/1173 for details on why reflect.DeepEqual no longer works for proto messages
 func DeepEqual(val1, val2 interface{}) bool {
-	protoVal1, isProto := val1.(proto.Message)
+	protoVal1, isProto := val1.(protoV2.Message)
 	if isProto {
-		protoVal2, isProto := val2.(proto.Message)
+		protoVal2, isProto := val2.(protoV2.Message)
 		if !isProto {
 			return false // different types
 		}
-		return proto.Equal(protoVal1, protoVal2)
+		return protoV2.Equal(protoVal1, protoVal2)
 	}
 	return reflect.DeepEqual(val1, val2)
 }


### PR DESCRIPTION
Fix equality for protos, since we were using the `proto.Equals` on k8s resources that implemented the protov1 interface but should have been using reflection for equality.

The k8s resources don't implement protov2, so use that as our check instead

BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/207