### PR TITLE
Proto compiler optimizations and metrics

### DIFF
--- a/changelog/v0.17.16/proto-compiler-optimization.yaml
+++ b/changelog/v0.17.16/proto-compiler-optimization.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4559
+    resolvesIssue: false
+    description: Adds memoization to proto compilation to reduce execution time.

--- a/codegen/cmd.go
+++ b/codegen/cmd.go
@@ -199,8 +199,6 @@ func (c Command) renderProtos() ([]*collector.DescriptorWithPath, error) {
 }
 
 func (c Command) generateGroup(grp model.Group, descriptors []*collector.DescriptorWithPath) error {
-	defer metrics.MeasureElapsed("generate-group", time.Now())
-
 	c.addDescriptorsToGroup(&grp, descriptors)
 
 	fileWriter := &writer.DefaultFileWriter{

--- a/codegen/collector/collector.go
+++ b/codegen/collector/collector.go
@@ -1,12 +1,17 @@
 package collector
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
+	"time"
+
+	"github.com/solo-io/skv2/codegen/metrics"
 
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/log"
@@ -19,23 +24,33 @@ type Collector interface {
 
 func NewCollector(customImports, commonImports []string) *collector {
 	return &collector{
-		customImports: customImports,
-		commonImports: commonImports,
+		customImports:    customImports,
+		commonImports:    commonImports,
+		importsExtractor: NewSynchronizedImportsExtractor(),
 	}
 }
 
 type collector struct {
 	customImports []string
 	commonImports []string
+
+	// The collector traverses a tree of files, opening and parsing each one.
+	// These are costly operations that are often duplicated (ie fileA and fileB both import fileC)
+	// The importsExtractor allows us to separate *how* to fetch imports from a file
+	// from *when* to fetch imports from a file. This allows us to define a caching layer
+	// in the importsExtractor and the collector doesn't have to be aware of it.
+	importsExtractor ImportsExtractor
 }
 
 func (c *collector) CollectImportsForFile(root, protoFile string) ([]string, error) {
-	return c.importsForProtoFile(root, protoFile, c.customImports)
+	return c.synchronizedImportsForProtoFile(root, protoFile, c.customImports)
 }
 
 var protoImportStatementRegex = regexp.MustCompile(`.*import "(.*)";.*`)
 
 func (c *collector) detectImportsForFile(file string) ([]string, error) {
+	metrics.IncrementFrequency("collector-opened-files")
+
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
 		return nil, err
@@ -55,6 +70,15 @@ func (c *collector) detectImportsForFile(file string) ([]string, error) {
 	return protoImports, nil
 }
 
+func (c *collector) synchronizedImportsForProtoFile(absoluteRoot, protoFile string, customImports []string) ([]string, error) {
+	// Define how we will extract the imports for the proto file
+	importsFetcher := func(protoFileName string) ([]string, error) {
+		return c.importsForProtoFile(absoluteRoot, protoFileName, customImports)
+	}
+
+	return c.importsExtractor.FetchImportsForFile(protoFile, importsFetcher)
+}
+
 func (c *collector) importsForProtoFile(absoluteRoot, protoFile string, customImports []string) ([]string, error) {
 	importStatements, err := c.detectImportsForFile(protoFile)
 	if err != nil {
@@ -67,7 +91,7 @@ func (c *collector) importsForProtoFile(absoluteRoot, protoFile string, customIm
 			return nil, err
 		}
 		dependency := filepath.Join(importPath, importedProto)
-		dependencyImports, err := c.importsForProtoFile(absoluteRoot, dependency, customImports)
+		dependencyImports, err := c.synchronizedImportsForProtoFile(absoluteRoot, dependency, customImports)
 		if err != nil {
 			return nil, eris.Wrapf(err, "getting imports for dependency")
 		}
@@ -130,4 +154,134 @@ func (c *collector) findImportRelativeToRoot(absoluteRoot, importedProtoFile str
 	}
 	return possibleImportPaths[0], nil
 
+}
+
+type ImportsFetcher func(file string) ([]string, error)
+
+type ImportsExtractor interface {
+	FetchImportsForFile(protoFile string, importsFetcher ImportsFetcher) ([]string, error)
+}
+
+// thread-safe
+// The synchronizedImportsExtractor provides synchronized access to imports for a given proto file.
+// It provides 2 useful features for tree traversal:
+//	1. Imports for each file are cached, ensuring that if we attempt to access that file
+//		during traversal again, we do not need to duplicate work.
+//	2. If imports for a file are unknown, and simultaneous go routines attempt to load
+//		the imports, only 1 will execute and the other will block, waiting for the result.
+//		This reduces the number of times we open and parse files.
+type synchronizedImportsExtractor struct {
+	// cachedImports contains a map of fileImports, each indexed by their file name
+	cachedImports sync.Map
+
+	// protect access to activeRequests
+	activeRequestsMu sync.RWMutex
+	activeRequests   map[string]*importsFetchRequest
+}
+
+type fileImports struct {
+	imports []string
+	err     error
+}
+
+func NewSynchronizedImportsExtractor() ImportsExtractor {
+	return &synchronizedImportsExtractor{
+		activeRequests: map[string]*importsFetchRequest{},
+	}
+}
+
+func (i *synchronizedImportsExtractor) FetchImportsForFile(protoFile string, importsFetcher ImportsFetcher) ([]string, error) {
+	// Attempt to load the imports from the cache
+	cachedImports, ok := i.cachedImports.Load(protoFile)
+	if ok {
+		typedCachedImports := cachedImports.(*fileImports)
+		return typedCachedImports.imports, typedCachedImports.err
+	}
+
+	i.activeRequestsMu.Lock()
+
+	// Ensure that we do not wait forever
+	ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// If there's not a current active request for this file, create one.
+	activeRequest := i.activeRequests[protoFile]
+	if activeRequest == nil {
+		activeRequest = newImportsFetchRequest()
+		i.activeRequests[protoFile] = activeRequest
+
+		// This goroutine has exclusive ownership over the current request.
+		// It releases the resource by nil'ing the importRequest field
+		// once the goroutine is done.
+		go func(requestCtx context.Context) {
+			// fetch the imports
+			imports, err := importsFetcher(protoFile)
+
+			// update the cache
+			i.cachedImports.Store(protoFile, &fileImports{imports: imports, err: err})
+
+			// Signal to waiting goroutines
+			activeRequest.done(imports, err)
+
+			// Free active request so a different request can run.
+			i.activeRequestsMu.Lock()
+			defer i.activeRequestsMu.Unlock()
+			delete(i.activeRequests, protoFile)
+		}(ctxWithTimeout)
+	}
+
+	inflightRequest := i.activeRequests[protoFile]
+	i.activeRequestsMu.Unlock()
+
+	select {
+	case <-ctxWithTimeout.Done():
+		// We should never reach this. This can only occur if we deadlock on file imports
+		// which only happens with cyclic dependencies
+		// Perhaps a safer alternative to erroring is just to execute the importsFetcher:
+		// 	return importsFetcher(protoFile)
+		return nil, ctxWithTimeout.Err()
+	case <-inflightRequest.wait():
+		// Wait for the existing request to complete, then return
+		return inflightRequest.result()
+	}
+}
+
+// importsFetchRequest is used to wait on some in-flight request from multiple goroutines.
+// Derived from: https://github.com/coreos/go-oidc/blob/08563f61dbb316f8ef85b784d01da503f2480690/oidc/jwks.go#L53
+type importsFetchRequest struct {
+	doneCh  chan struct{}
+	imports []string
+	err     error
+}
+
+func newImportsFetchRequest() *importsFetchRequest {
+	return &importsFetchRequest{doneCh: make(chan struct{})}
+}
+
+// wait returns a channel that multiple goroutines can receive on. Once it returns
+// a value, the inflight request is done and result() can be inspected.
+func (i *importsFetchRequest) wait() <-chan struct{} {
+	return i.doneCh
+}
+
+// done can only be called by a single goroutine. It records the result of the
+// inflight request and signals other goroutines that the result is safe to
+// inspect.
+func (i *importsFetchRequest) done(imports []string, err error) {
+	i.imports = imports
+	i.err = err
+	close(i.doneCh)
+}
+
+// result cannot be called until the wait() channel has returned a value.
+func (i *importsFetchRequest) result() ([]string, error) {
+	return i.imports, i.err
+}
+
+// This is the old implementation, that does not include caching or locking
+type primitiveImportsExtractor struct {
+}
+
+func (p *primitiveImportsExtractor) FetchImportsForFile(protoFile string, importsFetcher ImportsFetcher) ([]string, error) {
+	return importsFetcher(protoFile)
 }

--- a/codegen/collector/compiler.go
+++ b/codegen/collector/compiler.go
@@ -9,6 +9,9 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
+
+	"github.com/solo-io/skv2/codegen/metrics"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -56,6 +59,8 @@ type protoCompiler struct {
 }
 
 func (p *protoCompiler) CompileDescriptorsFromRoot(root string, skipDirs []string) ([]*DescriptorWithPath, error) {
+	defer metrics.MeasureElapsed("proto-compiler", time.Now())
+
 	var descriptors []*DescriptorWithPath
 	var mutex sync.Mutex
 	addDescriptor := func(f DescriptorWithPath) {

--- a/codegen/collector/compiler.go
+++ b/codegen/collector/compiler.go
@@ -155,10 +155,12 @@ var defaultGogoArgs = []string{
 
 func (p *protoCompiler) writeDescriptors(protoFile, toFile string, imports []string, compileProtos bool) error {
 	cmd := exec.Command("protoc")
-	for i := range imports {
-		imports[i] = "-I" + imports[i]
+
+	var cmdImports []string
+	for _, i := range imports {
+		cmdImports = append(cmdImports, fmt.Sprintf("-I%s", i))
 	}
-	cmd.Args = append(cmd.Args, imports...)
+	cmd.Args = append(cmd.Args, cmdImports...)
 	gogoArgs := append(defaultGogoArgs, p.customArgs...)
 
 	if compileProtos {

--- a/codegen/metrics/metrics.go
+++ b/codegen/metrics/metrics.go
@@ -1,0 +1,80 @@
+package metrics
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+var (
+	sink *metricSink
+)
+
+func NewSink() {
+	sink = newMetricSink()
+}
+
+func MeasureElapsed(key string, startTime time.Time) {
+	sink.setDurationMetric(keyWithGlobalNamespace(key), time.Since(startTime).String())
+}
+
+func IncrementFrequency(key string) {
+	sink.incrementFrequencyMetric(keyWithGlobalNamespace(key))
+}
+
+func keyWithGlobalNamespace(key string) string {
+	// ensure global keys are grouped together, and listed first in the map
+	return fmt.Sprintf("%s/%s", "@code-generator", key)
+}
+
+func Flush(writer io.Writer) error {
+	byt, err := sink.getMetrics()
+	if err != nil {
+		return err
+	}
+	_, err = writer.Write(byt)
+	return err
+}
+
+// This is a primitive implementation for compiling performance measurements of code-gen
+// If we need it, we could substitute this with something more heavy handed like:
+//	https://github.com/armon/go-metrics
+type metricSink struct {
+	metricsMu sync.Mutex
+
+	DurationMetrics  map[string]string `json:"duration"`
+	FrequencyMetrics map[string]int64  `json:"frequency"`
+}
+
+func newMetricSink() *metricSink {
+	return &metricSink{
+		DurationMetrics:  map[string]string{},
+		FrequencyMetrics: map[string]int64{},
+	}
+}
+
+func (m *metricSink) setDurationMetric(key, value string) {
+	m.metricsMu.Lock()
+	defer m.metricsMu.Unlock()
+	m.DurationMetrics[key] = value
+}
+
+func (m *metricSink) incrementFrequencyMetric(key string) {
+	m.metricsMu.Lock()
+	defer m.metricsMu.Unlock()
+	v, ok := m.FrequencyMetrics[key]
+	if ok {
+		m.FrequencyMetrics[key] = v + 1
+	} else {
+		m.FrequencyMetrics[key] = 1
+	}
+}
+
+func (m *metricSink) getMetrics() ([]byte, error) {
+	m.metricsMu.Lock()
+	defer m.metricsMu.Unlock()
+
+	return json.MarshalIndent(m, "", "    ")
+}


### PR DESCRIPTION
# Work In Progress
I have verified this improves gloo (solo-projects), and have no reason to believe that gloo-mesh will behave differently, but I'd like to confirm that.

# Description

- When compiling protos, use memoization to reduce duplicated work
- Add some basic metrics around duration and frequency of execution, to better understand where bottlenecks are.

# Context

Some recent work in solo-kit (https://github.com/solo-io/solo-kit/pull/415) illustrated that proto compilation (which requires walking a tree of files, accumulating all the imports) takes a long time. This is due to the fact that for each import, we read that file and get those imports. This means, that if we fileA and fileB both import fileC, we will read/parse fileC twice. This grows as the dependency graph gets more complex. 

I added some simple metrics to understand the compilation bottleneck, and ran codegen for solo-projects. During solo-projects codegen, we rely on skv2 twice, first for the gloo fed protos and second for the api server protos. Below are the measurements for our existing implementation of proto compilation compared with the measurements from this change.

### Before (no caching)

Gloo Fed
```
{
    "duration": {
        "@code-generator/proto-compiler": "38.238680152s"
    },
    "frequency": {
        "@code-generator/collector-opened-files": 29051
    }
}
```

Api Server
```
{
    "duration": {
        "@code-generator/proto-compiler": "1m2.679936094s"
    },
    "frequency": {
        "@code-generator/collector-opened-files": 46697
    }
}
```

### After (with caching)

Gloo Fed
```
{
    "duration": {
        "@code-generator/proto-compiler": "9.828921368s"
    },
    "frequency": {
        "@code-generator/collector-opened-files": 145
    }
}
```

Api Server
```
{
    "duration": {
        "@code-generator/proto-compiler": "12.419879844s"
    },
    "frequency": {
        "@code-generator/collector-opened-files": 153
    }
}
```