### PR TITLE
remove controllerruntime dependency

### DIFF
--- a/changelog/v0.17.17/remove-controller-runtime-config-dep.yaml
+++ b/changelog/v0.17.17/remove-controller-runtime-config-dep.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Removes controller runtime dependency, to unblock projects that import skv2 that have a `kubeconfig` go flag.

--- a/ci/oss_compliance/osa_provided.md
+++ b/ci/oss_compliance/osa_provided.md
@@ -13,7 +13,6 @@ Name|Version|License
 [google/gofuzz](https://github.com/google/gofuzz)|v1.1.0|Apache License 2.0
 [google/uuid](https://github.com/google/uuid)|v1.2.0|BSD 3-clause "New" or "Revised" License
 [googleapis/gnostic](https://github.com/googleapis/gnostic)|v0.5.1|Apache License 2.0
-[imdario/mergo](https://github.com/imdario/mergo)|v0.3.10|BSD 3-clause "New" or "Revised" License
 [json-iterator/go](https://github.com/json-iterator/go)|v1.1.10|MIT License
 [golang_protobuf_extensions/pbutil](https://github.com/matttproud/golang_protobuf_extensions)|v1.0.2-0.20181231171920-c182affec369|Apache License 2.0
 [mitchellh/hashstructure](https://github.com/mitchellh/hashstructure)|v1.0.0|MIT License
@@ -25,7 +24,6 @@ Name|Version|License
 [prometheus/common](https://github.com/prometheus/common)|v0.15.0|Apache License 2.0
 [procfs/internal](https://github.com/prometheus/procfs)|v0.2.0|Apache License 2.0
 [rotisserie/eris](https://github.com/rotisserie/eris)|v0.1.1|MIT License
-[spf13/pflag](https://github.com/spf13/pflag)|v1.0.5|BSD 3-clause "New" or "Revised" License
 [go.uber.org/atomic](https://go.uber.org/atomic)|v1.7.0|MIT License
 [go.uber.org/multierr](https://go.uber.org/multierr)|v1.6.0|MIT License
 [go.uber.org/zap](https://go.uber.org/zap)|v1.16.0|MIT License
@@ -41,7 +39,6 @@ Name|Version|License
 [gopkg.in/yaml.v2](https://gopkg.in/yaml.v2)|v2.4.0|Apache License 2.0
 [gopkg.in/yaml.v3](https://gopkg.in/yaml.v3)|v3.0.0-20200615113413-eeeca48fe776|MIT License
 [k8s.io/api](https://k8s.io/api)|v0.19.6|Apache License 2.0
-[apiextensions/v1beta1](https://k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1)|v0.19.6|Apache License 2.0
 [k8s.io/apimachinery](https://k8s.io/apimachinery)|v0.19.6|Apache License 2.0
 [k8s.io/client-go](https://k8s.io/client-go)|v0.19.6|Apache License 2.0
 [config/v1alpha1](https://k8s.io/component-base/config/v1alpha1)|v0.19.6|Apache License 2.0

--- a/pkg/ezkube/ensurer.go
+++ b/pkg/ezkube/ensurer.go
@@ -2,12 +2,12 @@ package ezkube
 
 import (
 	"context"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/solo-io/skv2/pkg/utils"
 	"k8s.io/client-go/util/retry"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	controllerruntime "sigs.k8s.io/controller-runtime"
 )
 
 type ensurer struct {
@@ -23,7 +23,7 @@ func NewEnsurer(restClient RestClient) *ensurer {
 
 func (c *ensurer) Ensure(ctx context.Context, parent Object, child Object, reconcileFuncs ...ReconcileFunc) error {
 	if parent != nil {
-		if err := controllerruntime.SetControllerReference(parent, child, c.Manager().GetScheme()); err != nil {
+		if err := controllerutil.SetControllerReference(parent, child, c.Manager().GetScheme()); err != nil {
 			return err
 		}
 	}

--- a/pkg/ezkube/ensurer.go
+++ b/pkg/ezkube/ensurer.go
@@ -2,6 +2,7 @@ package ezkube
 
 import (
 	"context"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/solo-io/skv2/pkg/utils"


### PR DESCRIPTION
The `runtimecontroller/config` package adds a global flag `kubeconfig` which is causing errors in flagger. This is a quick and dirty replacement so we don't depend on `runtimecontroller/config` package.