### PR TITLE
Verify resource exists before sync

### DIFF
--- a/changelog/v0.19.4/verify-resource-exists-snapshot.yaml
+++ b/changelog/v0.19.4/verify-resource-exists-snapshot.yaml
@@ -1,4 +1,4 @@
 changelog:
   - type: NON_USER_FACING
-    issueLink: https://github.com/solo-io/skv2/issues/284
+    issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/987
     description: Add check that if crd does not exist, do not attempt to sync the output snapshot for that resource.

--- a/changelog/v0.19.4/verify-resource-exists-snapshot.yaml
+++ b/changelog/v0.19.4/verify-resource-exists-snapshot.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/skv2/issues/284
+    description: Add check that if crd does not exist, do not attempt to sync the output snapshot for that resource.

--- a/contrib/codegen/templates/output/output_snapshot.gotmpl
+++ b/contrib/codegen/templates/output/output_snapshot.gotmpl
@@ -17,6 +17,7 @@ import (
     "github.com/solo-io/skv2/contrib/pkg/output"
     "github.com/solo-io/skv2/pkg/ezkube"
     "sigs.k8s.io/controller-runtime/pkg/client"
+    "github.com/solo-io/skv2/pkg/verifier"
 
 
 {{- range $group := $groups }}
@@ -51,6 +52,16 @@ var SnapshotGVKs = []schema.GroupVersionKind{
     {{- end }}
 }
 
+// Options for writing resources of a given type
+type OutputOpts struct {
+{{/* generate output options here */}}
+    // error handler
+    errHandler output.ErrorHandler
+
+    // If provided, ensure the resource has been verified before adding it to snapshots
+    Verifier verifier.OutputResourceVerifier
+}
+
 // the snapshot of output resources produced by a translation
 type Snapshot interface {
 {{/* generate a getter for each resource */}}
@@ -63,10 +74,10 @@ type Snapshot interface {
 {{- end }}
 
     // apply the snapshot to the local cluster, garbage collecting stale resources
-    ApplyLocalCluster(ctx context.Context, clusterClient client.Client, errHandler output.ErrorHandler)
+    ApplyLocalCluster(ctx context.Context, clusterClient client.Client, opts OutputOpts)
 
     // apply resources from the snapshot across multiple clusters, garbage collecting stale resources
-    ApplyMultiCluster(ctx context.Context, multiClusterClient multicluster.Client, errHandler output.ErrorHandler)
+     ApplyMultiCluster(ctx context.Context, multiClusterClient multicluster.Client, opts OutputOpts)
 
     // serialize the entire snapshot as JSON
     MarshalJSON() ([]byte, error)
@@ -209,8 +220,9 @@ func NewSinglePartitionedSnapshot(
 
 
 // apply the desired resources to the cluster state; remove stale resources where necessary
-func (s *snapshot) ApplyLocalCluster(ctx context.Context, cli client.Client, errHandler output.ErrorHandler) {
+func (s *snapshot) ApplyLocalCluster(ctx context.Context, clusterClient client.Client, opts OutputOpts) {
     var genericLists []output.ResourceList
+    var presentResources []output.ResourceList
 
 {{/* generate each list conversion */}}
 {{- range $group := $groups }}
@@ -220,18 +232,38 @@ func (s *snapshot) ApplyLocalCluster(ctx context.Context, cli client.Client, err
     for _, outputSet := range s.{{ $kindLowerCamelPlural }} {
         genericLists = append(genericLists,  outputSet.Generic())
     }
+
+    for _, resource := range genericLists {
+         if opts.Verifier != nil {
+            gvk := schema.GroupVersionKind{
+                Group: "{{ $resource.Group.Group }}",
+                Version: "{{ $resource.Version }}",
+                Kind: "{{ $resource.Kind }}",
+            }
+
+            if resourceRegistered, err := opts.Verifier.VerifyServerResource(
+                cluster,
+                gvk,
+            ); err != nil{
+                return err
+            } else if resourceRegistered {
+               presentResources = append(presentResources,  resource)
+            }
+         }
+    }
 {{- end }}
 {{- end }}
 
     output.Snapshot{
         Name:        s.name,
-        ListsToSync: genericLists,
-    }.SyncLocalCluster(ctx, cli, errHandler)
+        ListsToSync: presentResources,
+    }.SyncLocalCluster(ctx, cli, opts.errHandler)
 }
 
 // apply the desired resources to multiple cluster states; remove stale resources where necessary
-func (s *snapshot) ApplyMultiCluster(ctx context.Context, multiClusterClient multicluster.Client, errHandler output.ErrorHandler) {
+func (s *snapshot) ApplyMultiCluster(ctx context.Context, multiClusterClient multicluster.Client, opts OutputOpts) error {
     var genericLists []output.ResourceList
+    var presentResources []output.ResourceList
 
 {{/* generate each list conversion */}}
 {{- range $group := $groups }}
@@ -240,6 +272,25 @@ func (s *snapshot) ApplyMultiCluster(ctx context.Context, multiClusterClient mul
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
     for _, outputSet := range s.{{ $kindLowerCamelPlural }} {
         genericLists = append(genericLists,  outputSet.Generic())
+    }
+
+    for _, resource := range genericLists {
+         if opts.Verifier != nil {
+            gvk := schema.GroupVersionKind{
+                Group:   resource.Group.Group,
+                Version: resource.Group.Version,
+                Kind:    resource.Kind,
+            }
+
+            if resourceRegistered, err := opts.Verifier.VerifyServerResource(
+                cluster,
+                gvk,
+            ); err != nil{
+                return err
+            } else if resourceRegistered {
+               presentResources = append(presentResources,  resource)
+            }
+         }
     }
 {{- end }}
 {{- end }}
@@ -247,8 +298,8 @@ func (s *snapshot) ApplyMultiCluster(ctx context.Context, multiClusterClient mul
     output.Snapshot{
         Name:        s.name,
         Clusters:    s.clusters,
-        ListsToSync: genericLists,
-    }.SyncMultiCluster(ctx, multiClusterClient, errHandler)
+        ListsToSync: presentResources,
+    }.SyncMultiCluster(ctx, multiClusterClient, opts.errHandler)
 }
 
 func (s *snapshot) Generic() resource.ClusterSnapshot {

--- a/contrib/codegen/templates/output/output_snapshot.gotmpl
+++ b/contrib/codegen/templates/output/output_snapshot.gotmpl
@@ -31,8 +31,8 @@ import (
 
 // this error can occur if constructing a Partitioned Snapshot from a resource
 // that is missing the partition label
-var MissingRequiredLabelError = func(labelKey, resourceKind string, obj ezkube.ResourceId) error {
-    return eris.Errorf("expected label %v not on labels of %v %v", labelKey, resourceKind, sets.Key(obj))
+var MissingRequiredLabelError = func(labelKey, gvk schema.GroupVersionKind, obj ezkube.ResourceId) error {
+    return eris.Errorf("expected label %v not on labels of %v %v", labelKey, gvk.String(), sets.Key(obj))
 }
 
 // SnapshotGVKs is a list of the GVKs included in this snapshot
@@ -448,7 +448,11 @@ func (l labeled{{ $resource.Kind }}Set) Generic() output.ResourceList {
     return output.ResourceList{
         Resources: desiredResources,
         ListFunc: listFunc,
-        ResourceKind: "{{ $resource.Kind }}",
+        GVK: schema.GroupVersionKind{
+            Group: "{{ $resource.Group.Group }}",
+            Version: "{{ $resource.Version }}",
+            Kind: "{{ $resource.Kind }}",
+        },
     }
 }
 

--- a/contrib/codegen/templates/output/output_snapshot.gotmpl
+++ b/contrib/codegen/templates/output/output_snapshot.gotmpl
@@ -31,7 +31,7 @@ import (
 
 // this error can occur if constructing a Partitioned Snapshot from a resource
 // that is missing the partition label
-var MissingRequiredLabelError = func(labelKey, gvk schema.GroupVersionKind, obj ezkube.ResourceId) error {
+var MissingRequiredLabelError = func(labelKey string, gvk schema.GroupVersionKind, obj ezkube.ResourceId) error {
     return eris.Errorf("expected label %v not on labels of %v %v", labelKey, gvk.String(), sets.Key(obj))
 }
 

--- a/contrib/codegen/templates/output/output_snapshot.gotmpl
+++ b/contrib/codegen/templates/output/output_snapshot.gotmpl
@@ -123,6 +123,7 @@ func NewSnapshot(
 func NewLabelPartitionedSnapshot(
 	name,
 	labelKey string, // the key by which to partition the resources
+	gvk schema.GroupVersionKind,
 {{/* generate partitioned constructor params here */}}
 {{- range $group := $groups }}
 {{ $set_import_prefix := printf "%v_sets" (group_import_name $group) }}
@@ -141,7 +142,7 @@ func NewLabelPartitionedSnapshot(
 {{- $kindPlural := pluralize $resource.Kind }}
 {{- $kindLowerCamel := lower_camel $resource.Kind }}
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
-    partitioned{{ $kindPlural }}, err := partition{{ $kindPlural }}ByLabel(labelKey, {{ $kindLowerCamelPlural }})
+    partitioned{{ $kindPlural }}, err := partition{{ $kindPlural }}ByLabel(labelKey, gvk, {{ $kindLowerCamelPlural }})
     if err != nil {
     	return nil, err
     }
@@ -294,16 +295,16 @@ func (s *snapshot) ForEachObject(handleObject func(cluster string, gvk schema.Gr
 {{- $kindLowerCamel := lower_camel $resource.Kind }}
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
 
-func partition{{ $kindPlural }}ByLabel(labelKey string, set {{ $set_import_prefix }}.{{ $resource.Kind }}Set) ([]Labeled{{ $resource.Kind }}Set, error) {
+func partition{{ $kindPlural }}ByLabel(labelKey string, gvk schema.GroupVersionKind, set {{ $set_import_prefix }}.{{ $resource.Kind }}Set) ([]Labeled{{ $resource.Kind }}Set, error) {
     setsByLabel := map[string]{{ $set_import_prefix }}.{{ $resource.Kind }}Set{}
 
     for _, obj := range set.List() {
         if obj.Labels == nil {
-            return nil, MissingRequiredLabelError(labelKey, "{{ $resource.Kind }}", obj)
+            return nil, MissingRequiredLabelError(labelKey, gvk, obj)
         }
         labelValue := obj.Labels[labelKey]
         if labelValue == "" {
-            return nil, MissingRequiredLabelError(labelKey, "{{ $resource.Kind }}", obj)
+            return nil, MissingRequiredLabelError(labelKey, gvk, obj)
         }
 
         setForValue, ok := setsByLabel[labelValue]
@@ -510,7 +511,7 @@ type Builder interface {
 {{- end }}
 
     // build the collected outputs into a label-partitioned snapshot
-    BuildLabelPartitionedSnapshot(labelKey string) (Snapshot, error)
+    BuildLabelPartitionedSnapshot(labelKey string, gvk schema.GroupVersionKind) (Snapshot, error)
 
     // build the collected outputs into a snapshot with a single partition
     BuildSinglePartitionedSnapshot(snapshotLabels map[string]string) (Snapshot, error)
@@ -564,10 +565,11 @@ func (b *builder) Get{{ $kindPlural }}() {{ $set_import_prefix }}.{{ $resource.K
 {{- end }}
 {{- end }}
 
-func (b *builder) BuildLabelPartitionedSnapshot(labelKey string) (Snapshot, error) {
+func (b *builder) BuildLabelPartitionedSnapshot(labelKey string, gvk schema.GroupVersionKind) (Snapshot, error) {
     return NewLabelPartitionedSnapshot(
         b.name,
         labelKey,
+        gvk,
 {{- range $group := $groups }}
     {{ $set_import_prefix := printf "%v_sets" (group_import_name $group) }}
     {{- range $resource := $group.Resources }}

--- a/contrib/codegen/templates/output/output_snapshot.gotmpl
+++ b/contrib/codegen/templates/output/output_snapshot.gotmpl
@@ -52,16 +52,6 @@ var SnapshotGVKs = []schema.GroupVersionKind{
     {{- end }}
 }
 
-// Options for writing resources of a given type
-type OutputOpts struct {
-{{/* generate output options here */}}
-    // error handler
-    errHandler output.ErrorHandler
-
-    // If provided, ensure the resource has been verified before adding it to snapshots
-    Verifier verifier.OutputResourceVerifier
-}
-
 // the snapshot of output resources produced by a translation
 type Snapshot interface {
 {{/* generate a getter for each resource */}}
@@ -74,10 +64,10 @@ type Snapshot interface {
 {{- end }}
 
     // apply the snapshot to the local cluster, garbage collecting stale resources
-    ApplyLocalCluster(ctx context.Context, clusterClient client.Client, opts OutputOpts)
+    ApplyLocalCluster(ctx context.Context, clusterClient client.Client, opts output.OutputOpts)
 
     // apply resources from the snapshot across multiple clusters, garbage collecting stale resources
-     ApplyMultiCluster(ctx context.Context, multiClusterClient multicluster.Client, opts OutputOpts)
+     ApplyMultiCluster(ctx context.Context, multiClusterClient multicluster.Client, opts output.OutputOpts)
 
     // serialize the entire snapshot as JSON
     MarshalJSON() ([]byte, error)
@@ -220,9 +210,8 @@ func NewSinglePartitionedSnapshot(
 
 
 // apply the desired resources to the cluster state; remove stale resources where necessary
-func (s *snapshot) ApplyLocalCluster(ctx context.Context, clusterClient client.Client, opts OutputOpts) {
+func (s *snapshot) ApplyLocalCluster(ctx context.Context, clusterClient client.Client, opts output.OutputOpts) {
     var genericLists []output.ResourceList
-    var presentResources []output.ResourceList
 
 {{/* generate each list conversion */}}
 {{- range $group := $groups }}
@@ -231,39 +220,19 @@ func (s *snapshot) ApplyLocalCluster(ctx context.Context, clusterClient client.C
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
     for _, outputSet := range s.{{ $kindLowerCamelPlural }} {
         genericLists = append(genericLists,  outputSet.Generic())
-    }
-
-    for _, resource := range genericLists {
-         if opts.Verifier != nil {
-            gvk := schema.GroupVersionKind{
-                Group: "{{ $resource.Group.Group }}",
-                Version: "{{ $resource.Version }}",
-                Kind: "{{ $resource.Kind }}",
-            }
-
-            if resourceRegistered, err := opts.Verifier.VerifyServerResource(
-                cluster,
-                gvk,
-            ); err != nil{
-                return err
-            } else if resourceRegistered {
-               presentResources = append(presentResources,  resource)
-            }
-         }
     }
 {{- end }}
 {{- end }}
 
     output.Snapshot{
         Name:        s.name,
-        ListsToSync: presentResources,
-    }.SyncLocalCluster(ctx, cli, opts.errHandler)
+        ListsToSync: genericLists,
+    }.SyncLocalCluster(ctx, clusterClient, opts)
 }
 
 // apply the desired resources to multiple cluster states; remove stale resources where necessary
-func (s *snapshot) ApplyMultiCluster(ctx context.Context, multiClusterClient multicluster.Client, opts OutputOpts) error {
+func (s *snapshot) ApplyMultiCluster(ctx context.Context, multiClusterClient multicluster.Client, opts output.OutputOpts) {
     var genericLists []output.ResourceList
-    var presentResources []output.ResourceList
 
 {{/* generate each list conversion */}}
 {{- range $group := $groups }}
@@ -272,25 +241,6 @@ func (s *snapshot) ApplyMultiCluster(ctx context.Context, multiClusterClient mul
 {{- $kindLowerCamelPlural := pluralize $kindLowerCamel }}
     for _, outputSet := range s.{{ $kindLowerCamelPlural }} {
         genericLists = append(genericLists,  outputSet.Generic())
-    }
-
-    for _, resource := range genericLists {
-         if opts.Verifier != nil {
-            gvk := schema.GroupVersionKind{
-                Group:   resource.Group.Group,
-                Version: resource.Group.Version,
-                Kind:    resource.Kind,
-            }
-
-            if resourceRegistered, err := opts.Verifier.VerifyServerResource(
-                cluster,
-                gvk,
-            ); err != nil{
-                return err
-            } else if resourceRegistered {
-               presentResources = append(presentResources,  resource)
-            }
-         }
     }
 {{- end }}
 {{- end }}
@@ -298,8 +248,8 @@ func (s *snapshot) ApplyMultiCluster(ctx context.Context, multiClusterClient mul
     output.Snapshot{
         Name:        s.name,
         Clusters:    s.clusters,
-        ListsToSync: presentResources,
-    }.SyncMultiCluster(ctx, multiClusterClient, opts.errHandler)
+        ListsToSync: genericLists,
+    }.SyncMultiCluster(ctx, multiClusterClient, opts)
 }
 
 func (s *snapshot) Generic() resource.ClusterSnapshot {

--- a/contrib/pkg/output/snapshot.go
+++ b/contrib/pkg/output/snapshot.go
@@ -249,7 +249,6 @@ func (s Snapshot) SyncMultiCluster(ctx context.Context, mcClient multicluster.Cl
 		// if the cluster is not available, we will not error (simply skip writing the resources here)
 		for _, cluster := range s.Clusters {
 			listForCluster := listsByCluster[cluster]
-			var presentResources []ezkube.Object
 
 			cli, err := mcClient.Cluster(cluster)
 			if err != nil {
@@ -260,22 +259,8 @@ func (s Snapshot) SyncMultiCluster(ctx context.Context, mcClient multicluster.Cl
 				continue
 			}
 
-			for _, resource := range listForCluster {
-				if opts.Verifier != nil {
-					gvk := resource.GetObjectKind().GroupVersionKind()
-					resourceRegistered, _ := opts.Verifier.VerifyServerResource(
-						cluster,
-						gvk,
-					)
-
-					if resourceRegistered {
-						presentResources = append(presentResources, resource)
-					}
-				}
-			}
-
 			resourcesForCluster := ResourceList{
-				Resources: presentResources,
+				Resources: listForCluster,
 				ListFunc:  list.ListFunc,
 				GVK:       list.GVK,
 			}

--- a/contrib/pkg/output/snapshot.go
+++ b/contrib/pkg/output/snapshot.go
@@ -211,7 +211,7 @@ type Snapshot struct {
 // Options for writing resources of a given type
 type OutputOpts struct {
 	// error handler
-	errHandler ErrorHandler
+	ErrHandler ErrorHandler
 
 	// If provided, ensure the resource has been verified before adding it to snapshots
 	Verifier verifier.OutputResourceVerifier
@@ -247,7 +247,7 @@ func (s Snapshot) SyncLocalCluster(ctx context.Context, cli client.Client, opts 
 			StatusUpdate: list.StatusUpdate,
 		}
 
-		s.syncList(ctx, multicluster.LocalCluster, cli, resourcesForLocalCluster, opts.errHandler)
+		s.syncList(ctx, multicluster.LocalCluster, cli, resourcesForLocalCluster, opts.ErrHandler)
 	}
 }
 
@@ -267,7 +267,7 @@ func (s Snapshot) SyncMultiCluster(ctx context.Context, mcClient multicluster.Cl
 			if err != nil {
 				for _, object := range listForCluster {
 					// send a write error for every object in the cluster
-					opts.errHandler.HandleWriteError(object, err)
+					opts.ErrHandler.HandleWriteError(object, err)
 				}
 				continue
 			}
@@ -292,7 +292,7 @@ func (s Snapshot) SyncMultiCluster(ctx context.Context, mcClient multicluster.Cl
 				ResourceKind: list.ResourceKind,
 			}
 
-			s.syncList(ctx, cluster, cli, resourcesForCluster, opts.errHandler)
+			s.syncList(ctx, cluster, cli, resourcesForCluster, opts.ErrHandler)
 		}
 	}
 }

--- a/contrib/pkg/output/snapshot.go
+++ b/contrib/pkg/output/snapshot.go
@@ -217,7 +217,7 @@ func (s Snapshot) SyncLocalCluster(ctx context.Context, cli client.Client, errHa
 		listForLocalCluster := list.SplitByClusterName()[multicluster.LocalCluster]
 
 		var existingResource []ezkube.Object
-		for _, resource := range listForLocalCluster{
+		for _, resource := range listForLocalCluster {
 			err := cli.Get(ctx, skv2_resource.ToClientKey(resource), resource)
 			if err == nil {
 				// Only append resources whose crds exist

--- a/contrib/pkg/output/snapshot.go
+++ b/contrib/pkg/output/snapshot.go
@@ -3,6 +3,7 @@ package output
 import (
 	"context"
 	"fmt"
+
 	"github.com/rotisserie/eris"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 

--- a/contrib/pkg/output/snapshot.go
+++ b/contrib/pkg/output/snapshot.go
@@ -14,7 +14,6 @@ import (
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/skv2/pkg/controllerutils"
 	"github.com/solo-io/skv2/pkg/ezkube"
-	skv2_resource "github.com/solo-io/skv2/pkg/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -216,17 +215,8 @@ func (s Snapshot) SyncLocalCluster(ctx context.Context, cli client.Client, errHa
 	for _, list := range s.ListsToSync {
 		listForLocalCluster := list.SplitByClusterName()[multicluster.LocalCluster]
 
-		var existingResource []ezkube.Object
-		for _, resource := range listForLocalCluster {
-			err := cli.Get(ctx, skv2_resource.ToClientKey(resource), resource)
-			if err == nil {
-				// Only append resources whose crds exist
-				existingResource = append(existingResource, resource)
-			}
-		}
-
 		resourcesForLocalCluster := ResourceList{
-			Resources:    existingResource,
+			Resources:    listForLocalCluster,
 			ListFunc:     list.ListFunc,
 			ResourceKind: list.ResourceKind,
 			StatusUpdate: list.StatusUpdate,
@@ -239,7 +229,6 @@ func (s Snapshot) SyncLocalCluster(ctx context.Context, cli client.Client, errHa
 // sync the output snapshot to storage across multiple clusters.
 // uses the object's ClusterName to determine the correct destination cluster.
 func (s Snapshot) SyncMultiCluster(ctx context.Context, mcClient multicluster.Client, errHandler ErrorHandler) {
-
 	for _, list := range s.ListsToSync {
 		listsByCluster := list.SplitByClusterName()
 		// TODO(ilackarms): possible error case that we're ignoring here;

--- a/contrib/pkg/output/snapshot.go
+++ b/contrib/pkg/output/snapshot.go
@@ -216,7 +216,7 @@ func (s Snapshot) SyncLocalCluster(ctx context.Context, cli client.Client, errHa
 	for _, list := range s.ListsToSync {
 		listForLocalCluster := list.SplitByClusterName()[multicluster.LocalCluster]
 
-		existingResource := []ezkube.Object{}
+		var existingResource []ezkube.Object
 		for _, resource := range listForLocalCluster{
 			err := cli.Get(ctx, skv2_resource.ToClientKey(resource), resource)
 			if err == nil {

--- a/pkg/verifier/output_verifier.go
+++ b/pkg/verifier/output_verifier.go
@@ -1,0 +1,98 @@
+package verifier
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/go-utils/contextutils"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+)
+
+// ServerResourceVerifier verifies whether a given cluster server supports a given resource.
+type OutputResourceVerifier interface {
+	// VerifyServerResource verifies whether the API server for the given rest.Config supports the resource with the given GVK.
+	// For the "local/management" cluster, set cluster to ""
+	// Note that once a resource has been verified, the result will be cached for subsequent calls.
+	// Returns true if the resource is registered, false otherwise.
+	// an error will be returned if the ErrorIfNotPresent option is selected for the given GVK
+	VerifyServerResource(cluster string, gvk schema.GroupVersionKind) (bool, error)
+}
+
+type outputVerifier struct {
+	// used for logging
+	ctx context.Context
+
+	// set of per-resource-type verify options; default is Skip.
+	options     map[schema.GroupVersionKind]ServerVerifyOption
+	optionsLock sync.RWMutex
+
+	// set when a resource is successfully verified for the first time.
+	// future calls to VerifyServerResource will return quickly if the
+	// resources have already been verified for the cluster.
+	cachedVerificationResponses *cachedVerificationResponses
+
+	cfg *rest.Config
+}
+
+func NewOutputVerifier(
+	ctx context.Context,
+	cfg *rest.Config,
+	options map[schema.GroupVersionKind]ServerVerifyOption,
+) *outputVerifier {
+	if options == nil {
+		options = map[schema.GroupVersionKind]ServerVerifyOption{}
+	}
+	return &outputVerifier{
+		ctx:                         ctx,
+		cfg:                         cfg,
+		options:                     options,
+		cachedVerificationResponses: newCachedVerificationResponses(),
+	}
+}
+
+// Verify whether the API server for the given rest.Config supports the resource with the given GVK.
+func (v *outputVerifier) VerifyServerResource(cluster string, gvk schema.GroupVersionKind) (bool, error) {
+	responseCached, resourceVerified := v.cachedVerificationResponses.getCachedResponse(cluster, gvk)
+	if responseCached {
+		return resourceVerified, nil
+	}
+
+	// get option for this gvk
+	// defaults to skip
+	v.optionsLock.RLock()
+	verifyOption := v.options[gvk]
+	v.optionsLock.RUnlock()
+
+	if verifyOption == ServerVerifyOption_SkipVerify {
+		return true, nil
+	}
+
+	var resourceRegistered bool
+	if verifyFailed, err := verifyServerResource(v.cfg, gvk); err != nil {
+		if verifyFailed {
+			return false, eris.Wrap(err, "resource verify failed")
+		}
+
+		switch verifyOption {
+		case ServerVerifyOption_ErrorIfNotPresent:
+			return false, err
+		case ServerVerifyOption_WarnIfNotPresent:
+			contextutils.LoggerFrom(v.ctx).Warnf("%v not registered (fetch err: %v)", gvk, err)
+			resourceRegistered = false
+		case ServerVerifyOption_LogDebugIfNotPresent:
+			contextutils.LoggerFrom(v.ctx).Debugf("%v not registered (fetch err: %v)", gvk, err)
+			resourceRegistered = false
+		case ServerVerifyOption_IgnoreIfNotPresent:
+			resourceRegistered = false
+		}
+	} else {
+		resourceRegistered = true
+	}
+
+	// update cache
+	v.cachedVerificationResponses.setCachedResponse(cluster, gvk, resourceRegistered)
+
+	return resourceRegistered, nil
+}

--- a/pkg/verifier/output_verifier_test.go
+++ b/pkg/verifier/output_verifier_test.go
@@ -1,0 +1,52 @@
+package verifier_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	. "github.com/solo-io/skv2/pkg/verifier"
+)
+
+var _ = Describe("Output Verifier", func() {
+	It("verifies the server resources", func() {
+		cfg, err := config.GetConfig()
+		if err != nil {
+			Skip("skipping verifier test, requires active kubernetes cluster, failed to get rest config: " + err.Error())
+		}
+
+		gvkDoesntExist := schema.GroupVersionKind{
+			Group:   "doesnt",
+			Version: "v1",
+			Kind:    "Exist",
+		}
+		gvkDoesExist := schema.GroupVersionKind{
+			Group:   "",
+			Version: "v1",
+			Kind:    "Secret",
+		}
+
+		v := NewOutputVerifier(context.TODO(), cfg, map[schema.GroupVersionKind]ServerVerifyOption{
+			gvkDoesntExist: ServerVerifyOption_ErrorIfNotPresent,
+		})
+
+		resourceExists, err := v.VerifyServerResource("", gvkDoesntExist)
+		Expect(err).To(HaveOccurred())
+
+		resourceExists, err = v.VerifyServerResource("", gvkDoesExist)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resourceExists).To(BeTrue())
+
+		// ignore errors on doesn't exist
+		v = NewOutputVerifier(context.TODO(), cfg, map[schema.GroupVersionKind]ServerVerifyOption{
+			gvkDoesntExist: ServerVerifyOption_WarnIfNotPresent,
+		})
+
+		resourceExists, err = v.VerifyServerResource("", gvkDoesntExist)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resourceExists).To(BeFalse())
+	})
+})


### PR DESCRIPTION
When syncing the output snapshot to local cluster storage only write resources that exist. 
BOT NOTES: 
resolves https://github.com/solo-io/gloo-mesh-enterprise/issues/987