### PR TITLE
AddToScheme from SchemeBuilder

### DIFF
--- a/changelog/v0.19.8/add-to-scheme-change.yaml
+++ b/changelog/v0.19.8/add-to-scheme-change.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Update clients go template so that we use AddToScheme from the SchemeBuilder

--- a/codegen/templates/code/types/clients.gotmpl
+++ b/codegen/templates/code/types/clients.gotmpl
@@ -55,7 +55,7 @@ type clientSet struct {
 
 func NewClientsetFromConfig(cfg *rest.Config) (Clientset, error) {
     scheme := scheme.Scheme
-    if err := {{ $import_prefix }}AddToScheme(scheme); err != nil{
+    if err := {{ $import_prefix }}SchemeBuilder.AddToScheme(scheme); err != nil{
         return nil, err
     }
     client, err := client.New(cfg, client.Options{

--- a/codegen/test/api/things.test.io/v1/clients.go
+++ b/codegen/test/api/things.test.io/v1/clients.go
@@ -51,7 +51,7 @@ type clientSet struct {
 
 func NewClientsetFromConfig(cfg *rest.Config) (Clientset, error) {
 	scheme := scheme.Scheme
-	if err := AddToScheme(scheme); err != nil {
+	if err := SchemeBuilder.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 	client, err := client.New(cfg, client.Options{

--- a/pkg/api/multicluster.solo.io/v1alpha1/clients.go
+++ b/pkg/api/multicluster.solo.io/v1alpha1/clients.go
@@ -49,7 +49,7 @@ type clientSet struct {
 
 func NewClientsetFromConfig(cfg *rest.Config) (Clientset, error) {
 	scheme := scheme.Scheme
-	if err := AddToScheme(scheme); err != nil {
+	if err := SchemeBuilder.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 	client, err := client.New(cfg, client.Options{

--- a/pkg/multicluster/internal/k8s/admissionregistration.k8s.io/v1/clients.go
+++ b/pkg/multicluster/internal/k8s/admissionregistration.k8s.io/v1/clients.go
@@ -50,7 +50,7 @@ type clientSet struct {
 
 func NewClientsetFromConfig(cfg *rest.Config) (Clientset, error) {
 	scheme := scheme.Scheme
-	if err := admissionregistration_k8s_io_v1.AddToScheme(scheme); err != nil {
+	if err := admissionregistration_k8s_io_v1.SchemeBuilder.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 	client, err := client.New(cfg, client.Options{

--- a/pkg/multicluster/internal/k8s/apiextensions.k8s.io/v1beta1/clients.go
+++ b/pkg/multicluster/internal/k8s/apiextensions.k8s.io/v1beta1/clients.go
@@ -50,7 +50,7 @@ type clientSet struct {
 
 func NewClientsetFromConfig(cfg *rest.Config) (Clientset, error) {
 	scheme := scheme.Scheme
-	if err := apiextensions_k8s_io_v1beta1.AddToScheme(scheme); err != nil {
+	if err := apiextensions_k8s_io_v1beta1.SchemeBuilder.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 	client, err := client.New(cfg, client.Options{

--- a/pkg/multicluster/internal/k8s/certificates.k8s.io/v1beta1/clients.go
+++ b/pkg/multicluster/internal/k8s/certificates.k8s.io/v1beta1/clients.go
@@ -50,7 +50,7 @@ type clientSet struct {
 
 func NewClientsetFromConfig(cfg *rest.Config) (Clientset, error) {
 	scheme := scheme.Scheme
-	if err := certificates_k8s_io_v1beta1.AddToScheme(scheme); err != nil {
+	if err := certificates_k8s_io_v1beta1.SchemeBuilder.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 	client, err := client.New(cfg, client.Options{

--- a/pkg/multicluster/internal/k8s/core/v1/clients.go
+++ b/pkg/multicluster/internal/k8s/core/v1/clients.go
@@ -54,7 +54,7 @@ type clientSet struct {
 
 func NewClientsetFromConfig(cfg *rest.Config) (Clientset, error) {
 	scheme := scheme.Scheme
-	if err := v1.AddToScheme(scheme); err != nil {
+	if err := v1.SchemeBuilder.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 	client, err := client.New(cfg, client.Options{

--- a/pkg/multicluster/internal/k8s/rbac.authorization.k8s.io/v1/clients.go
+++ b/pkg/multicluster/internal/k8s/rbac.authorization.k8s.io/v1/clients.go
@@ -56,7 +56,7 @@ type clientSet struct {
 
 func NewClientsetFromConfig(cfg *rest.Config) (Clientset, error) {
 	scheme := scheme.Scheme
-	if err := rbac_authorization_k8s_io_v1.AddToScheme(scheme); err != nil {
+	if err := rbac_authorization_k8s_io_v1.SchemeBuilder.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 	client, err := client.New(cfg, client.Options{


### PR DESCRIPTION
This change is needed because the upstream Istio `IstioOperator` CR does not define `AddToScheme` in the import package that we use. We can also get their through `SchemeBuilder` so this change impacts all generated clients