### PR TITLE
Fix unstructured gen

### DIFF
--- a/codegen/proto/options.go
+++ b/codegen/proto/options.go
@@ -60,7 +60,7 @@ func (o Options) getUnstructuredFields(protoPkg string, rootMessage []string) ([
 			fieldPath = append(fieldPath, "*")
 		}
 
-		if field.OpenAPIValidationDisabled {
+		if field.OpenAPIValidationDisabled || isUnstructuredMessage(protoPkg, root) {
 			// we are in a leaf, return a single-level path
 			unstructuredFields = append(unstructuredFields, fieldPath)
 			continue
@@ -92,6 +92,15 @@ func (o Options) getUnstructuredFields(protoPkg string, rootMessage []string) ([
 		}
 	}
 	return unstructuredFields, nil
+}
+
+// returns true for proto struct type, which is recursive
+func isUnstructuredMessage(protoPkg string, m MessageOptions) bool {
+	switch {
+	case m.Message.GetName() == "Struct" && protoPkg == "google.protobuf":
+		return true
+	}
+	return false
 }
 
 func findNestedMsg(parent MessageOptions, nestedName string) (MessageOptions, error) {


### PR DESCRIPTION
fixes infinite recursion that happens when a `google.protobuf.Struct` is used in a proto