### PR TITLE
Lowercase service port name

### DIFF
--- a/changelog/v0.22.5/lowercase-service-port-name.yaml
+++ b/changelog/v0.22.5/lowercase-service-port-name.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Ensure that all port names are lowercased, due to the k8s restriction that
+      names for ports must only contain lowercase alphanumeric characters and -.

--- a/codegen/templates/chart/operator-deployment.yamltmpl
+++ b/codegen/templates/chart/operator-deployment.yamltmpl
@@ -173,7 +173,7 @@ spec:
   type: {{ $[[ $operatorVar ]].serviceType }}
   ports:
   [[- range $port := $operator.Service.Ports ]]
-  - name: [[ $port.Name ]]
+  - name: [[ lower $port.Name ]]
     port: {{ $[[ $operatorVar ]].ports.[[ $port.Name ]] }}
   [[- end ]]
 [[ end ]]


### PR DESCRIPTION
As with Kubernetes names in general, names for ports must only contain lowercase alphanumeric characters and -. Port names must also start and end with an alphanumeric character.

For example, the names 123-abc and web are valid, but 123_abc and -web are not.