### PR TITLE
Wrap error

### DIFF
--- a/changelog/v0.22.13/wrap-error.yaml
+++ b/changelog/v0.22.13/wrap-error.yaml
@@ -1,3 +1,5 @@
 changelog:
   - type: FIX
     description: Wrap reconcile error instead of logging before returning to avoid reduntant error logging
+    issueLink: https://github.com/solo-io/dev-portal/issues2159
+    resolvesIssue: false

--- a/changelog/v0.22.13/wrap-error.yaml
+++ b/changelog/v0.22.13/wrap-error.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: FIX
+    description: Wrap reconcile error instead of logging before returning to avoid reduntant error logging

--- a/pkg/reconcile/runner.go
+++ b/pkg/reconcile/runner.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/rotisserie/eris"
+
 	"github.com/solo-io/skv2/pkg/verifier"
 
 	"github.com/go-logr/logr"
@@ -203,8 +205,7 @@ func (ec *runnerReconciler) Reconcile(ctx context.Context, request Request) (rec
 
 	result, err := ec.reconciler.Reconcile(obj)
 	if err != nil {
-		logger.Error(err, "handler error. retrying")
-		return result, err
+		return result, eris.Wrap(err, "handler error. retrying")
 	}
 	logger.V(2).Info("handler success.", "result", result)
 


### PR DESCRIPTION
The kubernetes controller logs the error returned from `Reconcile()` [here](https://github.com/kubernetes-sigs/controller-runtime/blob/v0.11.0/pkg/internal/controller/controller.go#L317) so we should wrap the error with additional context rather than log before returning