### PR TITLE
cluster watcher namespaces

### DIFF
--- a/changelog/v0.25.0/secrets-watch-namespaces.yaml
+++ b/changelog/v0.25.0/secrets-watch-namespaces.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: BREAKING_CHANGE
+    description: >
+      NewClusterWatcher now takes in a third argument (`watchNamespaces`) to constrain the namespaces in which
+      secrets will be watched. If empty, then all namespaces will be watched (which is the existing behavior).
+    issueLink: https://github.com/solo-io/skv2/issues/399

--- a/codegen/render/kube_multicluster_test.go
+++ b/codegen/render/kube_multicluster_test.go
@@ -120,7 +120,7 @@ var _ = WithRemoteClusterContextDescribe("Multicluster", func() {
 
 		Describe("clientset", func() {
 			It("works", func() {
-				cw := watch.NewClusterWatcher(ctx, manager.Options{Namespace: ns})
+				cw := watch.NewClusterWatcher(ctx, manager.Options{Namespace: ns}, nil)
 				err := cw.Run(masterManager)
 				Expect(err).NotTo(HaveOccurred())
 				mcClientset := multicluster.NewClient(cw)
@@ -187,7 +187,7 @@ var _ = WithRemoteClusterContextDescribe("Multicluster", func() {
 			}
 
 			BeforeEach(func() {
-				cw = watch.NewClusterWatcher(ctx, manager.Options{Namespace: ns})
+				cw = watch.NewClusterWatcher(ctx, manager.Options{Namespace: ns}, nil)
 			})
 
 			It("works when a loop is registered before the watcher is started", func() {

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -155,10 +155,12 @@ func StartMulti(
 	if !localMode {
 		// construct multicluster watcher and client
 		clusterWatcher = watch.NewClusterWatcher(
-			ctx, manager.Options{
+			ctx,
+			manager.Options{
 				Namespace: "", // TODO (ilackarms): support configuring specific watch namespaces on remote clusters
 				Scheme:    mgr.GetScheme(),
 			},
+			nil,
 		)
 
 		mcClient = multicluster.NewClient(clusterWatcher)

--- a/pkg/multicluster/kubeconfig/kubeconfig_secret.go
+++ b/pkg/multicluster/kubeconfig/kubeconfig_secret.go
@@ -1,7 +1,6 @@
 package kubeconfig
 
 import (
-	"fmt"
 	"io/ioutil"
 
 	"github.com/rotisserie/eris"
@@ -83,14 +82,8 @@ func convertCertFilesToInline(cfg api.Config) error {
 
 // SecretToConfig extracts the cluster name and *Config from a KubeConfig secret.
 // If the provided secret is not a KubeConfig secret, an error is returned.
-func SecretToConfig(secret *kubev1.Secret, namespaced bool) (cluster string, config clientcmd.ClientConfig, err error) {
-	var clusterName string
-	if namespaced {
-		clusterName = fmt.Sprintf("%s.%s", secret.Namespace, secret.Name)
-	} else {
-		clusterName = secret.Name
-	}
-
+func SecretToConfig(secret *kubev1.Secret) (clusterName string, config clientcmd.ClientConfig, err error) {
+	clusterName = secret.Name
 	kubeConfigBytes, ok := secret.Data[Key]
 	if !ok {
 		return clusterName, nil, SecretHasNoKubeConfig(secret.ObjectMeta)

--- a/pkg/multicluster/kubeconfig/kubeconfig_secret.go
+++ b/pkg/multicluster/kubeconfig/kubeconfig_secret.go
@@ -1,6 +1,7 @@
 package kubeconfig
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"github.com/rotisserie/eris"
@@ -82,8 +83,14 @@ func convertCertFilesToInline(cfg api.Config) error {
 
 // SecretToConfig extracts the cluster name and *Config from a KubeConfig secret.
 // If the provided secret is not a KubeConfig secret, an error is returned.
-func SecretToConfig(secret *kubev1.Secret) (clusterName string, config clientcmd.ClientConfig, err error) {
-	clusterName = secret.Name
+func SecretToConfig(secret *kubev1.Secret, namespaced bool) (cluster string, config clientcmd.ClientConfig, err error) {
+	var clusterName string
+	if namespaced {
+		clusterName = fmt.Sprintf("%s.%s", secret.Namespace, secret.Name)
+	} else {
+		clusterName = secret.Name
+	}
+
 	kubeConfigBytes, ok := secret.Data[Key]
 	if !ok {
 		return clusterName, nil, SecretHasNoKubeConfig(secret.ObjectMeta)

--- a/pkg/multicluster/kubeconfig/predicate.go
+++ b/pkg/multicluster/kubeconfig/predicate.go
@@ -3,36 +3,64 @@ package kubeconfig
 import (
 	"reflect"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-var Predicate = predicate.Funcs{
-	CreateFunc: func(e event.CreateEvent) bool {
-		return isKubeConfigSecret(e.Object)
-	},
-	DeleteFunc: func(e event.DeleteEvent) bool {
-		return isKubeConfigSecret(e.Object)
-	},
-	UpdateFunc: func(e event.UpdateEvent) bool {
-		if isKubeConfigSecret(e.ObjectNew) {
-			// Ignore metadata changes.
-			oldSecret, newSecret := e.ObjectOld.(*corev1.Secret), e.ObjectNew.(*corev1.Secret)
-			return !reflect.DeepEqual(oldSecret.Data, newSecret.Data)
-		}
-		return false
-	},
-	GenericFunc: func(e event.GenericEvent) bool {
-		return isKubeConfigSecret(e.Object)
-	},
+func BuildPredicate(watchNamespaces []string) predicate.Funcs {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			if !isNamespaceWatched(watchNamespaces, e.Object.GetNamespace()) {
+				return false
+			}
+			return isKubeConfigSecret(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if !isNamespaceWatched(watchNamespaces, e.Object.GetNamespace()) {
+				return false
+			}
+			return isKubeConfigSecret(e.Object)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if !isNamespaceWatched(watchNamespaces, e.ObjectNew.GetNamespace()) {
+				return false
+			}
+			if isKubeConfigSecret(e.ObjectNew) {
+				// Ignore metadata changes.
+				oldSecret, newSecret := e.ObjectOld.(*corev1.Secret), e.ObjectNew.(*corev1.Secret)
+				return !reflect.DeepEqual(oldSecret.Data, newSecret.Data)
+			}
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			if !isNamespaceWatched(watchNamespaces, e.Object.GetNamespace()) {
+				return false
+			}
+			return isKubeConfigSecret(e.Object)
+		},
+	}
 }
 
 func isKubeConfigSecret(obj client.Object) bool {
 	if s, ok := obj.(*corev1.Secret); ok {
 		return s.Type == SecretType
+	}
+	return false
+}
+
+// If watchNamespaces is empty, then watch all namespaces. Otherwise, watch
+// only the specified namespaces.
+func isNamespaceWatched(watchNamespaces []string, namespace string) bool {
+	if len(watchNamespaces) == 0 {
+		return true
+	}
+
+	for _, ns := range watchNamespaces {
+		if ns == namespace {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/multicluster/kubeconfig/predicate_test.go
+++ b/pkg/multicluster/kubeconfig/predicate_test.go
@@ -1,0 +1,146 @@
+package kubeconfig_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/solo-io/skv2/pkg/multicluster/kubeconfig"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("KubeConfig Secret Predicate", func() {
+	Describe("BuildPredicate", func() {
+
+		It("does not process events for non-secrets", func() {
+			watchNamespaces := []string{}
+			pred := BuildPredicate(watchNamespaces)
+
+			obj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "configmap1",
+					Namespace: "ns1",
+				},
+				Data: map[string]string{
+					"a": "b",
+				},
+			}
+			Expect(pred.CreateFunc(event.CreateEvent{Object: obj})).To(BeFalse())
+			Expect(pred.DeleteFunc(event.DeleteEvent{Object: obj})).To(BeFalse())
+			Expect(pred.UpdateFunc(event.UpdateEvent{ObjectNew: obj})).To(BeFalse())
+			Expect(pred.GenericFunc(event.GenericEvent{Object: obj})).To(BeFalse())
+		})
+
+		It("does not process events for non-kubeconfig secrets", func() {
+			watchNamespaces := []string{}
+			pred := BuildPredicate(watchNamespaces)
+
+			obj := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: "ns1",
+				},
+				Type: corev1.SecretTypeOpaque,
+			}
+			Expect(pred.CreateFunc(event.CreateEvent{Object: obj})).To(BeFalse())
+			Expect(pred.DeleteFunc(event.DeleteEvent{Object: obj})).To(BeFalse())
+			Expect(pred.UpdateFunc(event.UpdateEvent{ObjectNew: obj})).To(BeFalse())
+			Expect(pred.GenericFunc(event.GenericEvent{Object: obj})).To(BeFalse())
+		})
+
+		It("processes events in all namespaces when watchNamespaces is empty", func() {
+			watchNamespaces := []string{}
+			pred := BuildPredicate(watchNamespaces)
+
+			objOld := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: "ns1",
+				},
+				Type: SecretType,
+				Data: map[string][]byte{
+					"a": []byte("b"),
+				},
+			}
+			objNew := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: "ns1",
+				},
+				Type: SecretType,
+				Data: map[string][]byte{
+					"c": []byte("d"),
+				},
+			}
+			Expect(pred.CreateFunc(event.CreateEvent{Object: objNew})).To(BeTrue())
+			Expect(pred.DeleteFunc(event.DeleteEvent{Object: objNew})).To(BeTrue())
+			Expect(pred.UpdateFunc(event.UpdateEvent{ObjectOld: objOld, ObjectNew: objNew})).To(BeTrue())
+			Expect(pred.GenericFunc(event.GenericEvent{Object: objNew})).To(BeTrue())
+		})
+
+		It("processes events only in watchNamespaces", func() {
+			watchNamespaces := []string{"ns1", "ns2"}
+			pred := BuildPredicate(watchNamespaces)
+
+			objOld := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: "ns2",
+				},
+				Type: SecretType,
+				Data: map[string][]byte{
+					"a": []byte("b"),
+				},
+			}
+			objNew := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: "ns2",
+				},
+				Type: SecretType,
+				Data: map[string][]byte{
+					"c": []byte("d"),
+				},
+			}
+			Expect(pred.CreateFunc(event.CreateEvent{Object: objNew})).To(BeTrue())
+			Expect(pred.DeleteFunc(event.DeleteEvent{Object: objNew})).To(BeTrue())
+			Expect(pred.UpdateFunc(event.UpdateEvent{ObjectOld: objOld, ObjectNew: objNew})).To(BeTrue())
+			Expect(pred.GenericFunc(event.GenericEvent{Object: objNew})).To(BeTrue())
+
+			// change to a non-watched namespace
+			objOld.ObjectMeta.Namespace = "ns3"
+			objNew.ObjectMeta.Namespace = "ns3"
+			Expect(pred.CreateFunc(event.CreateEvent{Object: objNew})).To(BeFalse())
+			Expect(pred.DeleteFunc(event.DeleteEvent{Object: objNew})).To(BeFalse())
+			Expect(pred.UpdateFunc(event.UpdateEvent{ObjectOld: objOld, ObjectNew: objNew})).To(BeFalse())
+			Expect(pred.GenericFunc(event.GenericEvent{Object: objNew})).To(BeFalse())
+		})
+
+		It("does not process update events when secret didn't change", func() {
+			watchNamespaces := []string{}
+			pred := BuildPredicate(watchNamespaces)
+
+			objOld := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: "ns1",
+				},
+				Type: SecretType,
+				Data: map[string][]byte{
+					"a": []byte("b"),
+				},
+			}
+			objNew := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: "ns1",
+				},
+				Type: SecretType,
+				Data: map[string][]byte{
+					"a": []byte("b"),
+				},
+			}
+			Expect(pred.UpdateFunc(event.UpdateEvent{ObjectOld: objOld, ObjectNew: objNew})).To(BeFalse())
+		})
+	})
+})

--- a/pkg/multicluster/watch/watcher.go
+++ b/pkg/multicluster/watch/watcher.go
@@ -51,8 +51,6 @@ func (c *clusterWatcher) Run(master manager.Manager) error {
 }
 
 func (c *clusterWatcher) ReconcileSecret(obj *v1.Secret) (reconcile.Result, error) {
-	contextutils.LoggerFrom(c.ctx).Infow("ReconcileSecret", zap.Any("name", obj.Name), zap.Any("namespace", obj.Namespace))
-
 	clusterName, clientCfg, err := kubeconfig.SecretToConfig(obj)
 	if err != nil {
 		return reconcile.Result{}, eris.Wrap(err, "failed to extract kubeconfig from secret")
@@ -68,7 +66,6 @@ func (c *clusterWatcher) ReconcileSecret(obj *v1.Secret) (reconcile.Result, erro
 		c.removeCluster(clusterName)
 	}
 
-	contextutils.LoggerFrom(c.ctx).Infow("ReconcileSecret - starting manager")
 	c.startManager(clusterName, restCfg)
 
 	return reconcile.Result{}, nil
@@ -95,7 +92,6 @@ func (s *clusterWatcher) ListClusters() []string {
 }
 
 func (c *clusterWatcher) startManager(clusterName string, restCfg *rest.Config) {
-	contextutils.LoggerFrom(c.ctx).Infow("startManager", zap.Any("clusterName", clusterName))
 	go func() { // this must be async because mgr.Start(ctx) is blocking
 		retryOptions := []retry.Option{
 			retry.Delay(time.Second),


### PR DESCRIPTION
Allow constraining watched secrets to specific namespaces. See https://github.com/solo-io/skv2/issues/399 for background.

BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/399