### PR TITLE
Add option to prevent docs from being generated for operator

### DIFF
--- a/changelog/v0.27.1/hide-docs-for-operator.yaml
+++ b/changelog/v0.27.1/hide-docs-for-operator.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Add `hideFromDocs` flag to the helm chart operator
+    issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/6844
+    resolvesIssue: false

--- a/changelog/v0.27.1/hide-docs-for-operator.yaml
+++ b/changelog/v0.27.1/hide-docs-for-operator.yaml
@@ -1,5 +1,0 @@
-changelog:
-  - type: NEW_FEATURE
-    description: Add `hideFromDocs` flag to the helm chart operator
-    issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/6844
-    resolvesIssue: false

--- a/changelog/v0.27.2/hide-docs-for-operator.yaml
+++ b/changelog/v0.27.2/hide-docs-for-operator.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Add `hideFromDocs` flag to the helm chart operator
+    issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/6844
+    resolvesIssue: false

--- a/codegen/model/chart.go
+++ b/codegen/model/chart.go
@@ -54,6 +54,9 @@ type Operator struct {
 
 	// Custom values to include at operator level
 	Values interface{}
+
+	// Prevent generation of docs for this operator
+	HideFromDocs bool
 }
 
 // values for Deployment template
@@ -147,6 +150,10 @@ func (c Chart) BuildChartValues() values.UserHelmValues {
 		sidecars := map[string]values.UserContainerValues{}
 		for _, sidecar := range operator.Deployment.Sidecars {
 			sidecars[sidecar.Name] = makeContainerDocs(sidecar.Container)
+		}
+
+		if operator.HideFromDocs {
+			continue
 		}
 
 		helmValues.Operators = append(helmValues.Operators, values.UserOperatorValues{

--- a/codegen/templates/chart/operator-deployment.yamltmpl
+++ b/codegen/templates/chart/operator-deployment.yamltmpl
@@ -41,7 +41,11 @@ metadata:
     [[ $key ]]: [[ $value ]]
     [[- end ]]
   name: [[ $operator.Name ]]
-  namespace: {{ .Release.Namespace }}
+  [[- if $operator.Namespace ]]
+    namespace: $operator.Namespace
+  [[- else ]]
+    namespace: {{ .Release.Namespace }}
+  [[- end ]]
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
**Overview**
- Adds an option to allow us to prevent docs from being generated for an operator. This is useful for the portal development work as we are adding a new portal operator for the `AgentChart` and would like to hide the docs until the portal server work has been completed.
- Tested against the portal server development branch here - https://github.com/solo-io/gloo-mesh-enterprise/pull/7049 confirmed that the docs that were previously generated are now deleted after adding `HideFromDocs: true` to the `portalOperator`