### PR TITLE
prevent data race on clustername annotation

### DIFF
--- a/changelog/v0.27.1/prevent-clustername-data-race.yaml
+++ b/changelog/v0.27.1/prevent-clustername-data-race.yaml
@@ -1,4 +1,6 @@
 changelog:
     - type: FIX
+      issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/7412
+      resolvesIssue: false
       description: |
         Prevent a data race from occurring when a resource's annotations map is accessed concurrently.

--- a/changelog/v0.27.1/prevent-clustername-data-race.yaml
+++ b/changelog/v0.27.1/prevent-clustername-data-race.yaml
@@ -1,0 +1,4 @@
+changelog:
+    - type: FIX
+      description: |
+        Prevent a data race from occurring when a resource's annotations map is accessed concurrently.

--- a/changelog/v0.27.1/prevent-clustername-data-race.yaml
+++ b/changelog/v0.27.1/prevent-clustername-data-race.yaml
@@ -1,6 +1,0 @@
-changelog:
-    - type: FIX
-      issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/7412
-      resolvesIssue: false
-      description: |
-        Prevent a data race from occurring when a resource's annotations map is accessed concurrently.

--- a/changelog/v0.27.2/prevent-clustername-data-race.yaml
+++ b/changelog/v0.27.2/prevent-clustername-data-race.yaml
@@ -1,0 +1,6 @@
+changelog:
+    - type: FIX
+      issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/7412
+      resolvesIssue: false
+      description: |
+        Prevent a data race from occurring when a resource's annotations map is accessed concurrently.

--- a/pkg/ezkube/resource_id.go
+++ b/pkg/ezkube/resource_id.go
@@ -104,7 +104,11 @@ func getDeprecatedClusterName(id ResourceId) string {
 	return ""
 }
 
+var mu sync.Mutex
+
 func GetClusterName(id ClusterResourceId) string {
+	mu.Lock()
+	defer mu.Unlock()
 	annotations := id.GetAnnotations()
 	if annotations == nil || annotations[ClusterAnnotation] == "" {
 		return getDeprecatedClusterName(id)
@@ -114,6 +118,8 @@ func GetClusterName(id ClusterResourceId) string {
 }
 
 func SetClusterName(obj client.Object, cluster string) {
+	mu.Lock()
+	defer mu.Unlock()
 	if obj.GetAnnotations() == nil {
 		obj.SetAnnotations(map[string]string{})
 	}


### PR DESCRIPTION
upgrading to go 1.20 on gme has exposed a data race when GetClusterName and SetClusterName are called simultaneously and try to access/set annotations map.

Added a mutex that is shared by both functions to prevent the race from being caused by these functions, note this doesn't fully prevent races happening on the annotations map.