### PR TITLE
add ability to generate chart schema.json

### DIFF
--- a/changelog/v0.27.2/schema-json.yaml
+++ b/changelog/v0.27.2/schema-json.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Adds ability to generate json schema for chart
+    issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/7186

--- a/codegen/model/values/helm_chart_values.go
+++ b/codegen/model/values/helm_chart_values.go
@@ -1,6 +1,8 @@
 package values
 
 import (
+	"reflect"
+
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 )
@@ -10,6 +12,7 @@ type UserHelmValues struct {
 	Operators        []UserOperatorValues
 	CustomValues     interface{}
 	ValuesInlineDocs *UserValuesInlineDocs
+	JsonSchema       UserJsonSchema
 }
 
 type UserOperatorValues struct {
@@ -32,6 +35,10 @@ func (u *UserValuesInlineDocs) LineLength() int {
 		return 0
 	}
 	return u.LineLengthLimit
+}
+
+type UserJsonSchema struct {
+	CustomTypeMapper func(reflect.Type, map[string]interface{}) interface{}
 }
 
 // document values structure for an operator

--- a/codegen/render/chart_renderer.go
+++ b/codegen/render/chart_renderer.go
@@ -8,14 +8,6 @@ type ChartRenderer struct {
 	templateRenderer
 }
 
-type ChartHeaderGenerator struct {
-	header string
-}
-
-func (g *ChartHeaderGenerator) Generate() string {
-	return g.header
-}
-
 var defaultChartInputs = inputTemplates{
 	"chart/operator-deployment.yamltmpl": {
 		Path: "templates/deployment.yaml",

--- a/codegen/render/chart_renderer.go
+++ b/codegen/render/chart_renderer.go
@@ -65,8 +65,7 @@ func (r ChartRenderer) Render(chart model.Chart) ([]OutFile, error) {
 
 	if chart.JsonSchema != nil {
 		templatesToRender["chart/values.schema.jsontmpl"] = OutFile{
-			Path:           "values.schema.json",
-			HeaderOverride: &ChartHeaderGenerator{header: ""},
+			Path: "values.schema.json",
 		}
 	}
 

--- a/codegen/render/chart_renderer.go
+++ b/codegen/render/chart_renderer.go
@@ -8,6 +8,14 @@ type ChartRenderer struct {
 	templateRenderer
 }
 
+type ChartHeaderGenerator struct {
+	header string
+}
+
+func (g *ChartHeaderGenerator) Generate() string {
+	return g.header
+}
+
 var defaultChartInputs = inputTemplates{
 	"chart/operator-deployment.yamltmpl": {
 		Path: "templates/deployment.yaml",
@@ -53,6 +61,13 @@ func (r ChartRenderer) Render(chart model.Chart) ([]OutFile, error) {
 	templatesToRender := defaultChartInputs
 	if len(chart.Operators) == 0 {
 		templatesToRender = chartInputsNoOperators
+	}
+
+	if chart.JsonSchema != nil {
+		templatesToRender["chart/values.schema.jsontmpl"] = OutFile{
+			Path:           "values.schema.json",
+			HeaderOverride: &ChartHeaderGenerator{header: ""},
+		}
 	}
 
 	files, err := r.renderCoreTemplates(templatesToRender, chart)

--- a/codegen/render/export_test.go
+++ b/codegen/render/export_test.go
@@ -1,6 +1,9 @@
 package render
 
-import goyaml "gopkg.in/yaml.v3"
+import (
+	"github.com/solo-io/skv2/codegen/model/values"
+	goyaml "gopkg.in/yaml.v3"
+)
 
 // this file makes some private package members visible for testing
 
@@ -10,4 +13,8 @@ func ToNode(v interface{}, commentsConfig yamlCommentsConfig) goyaml.Node {
 
 func FromNode(n goyaml.Node) string {
 	return fromNode(n)
+}
+
+func ToJSONSchema(values values.UserHelmValues) string {
+	return toJSONSchema(values)
 }

--- a/codegen/render/funcs.go
+++ b/codegen/render/funcs.go
@@ -575,6 +575,7 @@ func fromJSON(str string) map[string]interface{} {
 func toJSONSchema(values values.UserHelmValues) string {
 	reflector := createJsonSchemaReflector(values)
 	schema := new(jsonschema.Schema)
+	schema.Version = "https://json-schema.org/draft/2020-12/schema"
 
 	// add json schema properties from the chart's custom values
 	if values.CustomValues != nil {
@@ -857,6 +858,7 @@ func jsonSchemaForOperator(
 	o *values.UserOperatorValues,
 ) *jsonschema.Schema {
 	schema := reflector.Reflect(o.Values)
+	schema.Version = "" // will be set on parent object
 
 	// if the opeartor defines custom values, add the properties to the schema
 	if o.CustomValues != nil {

--- a/codegen/render/funcs.go
+++ b/codegen/render/funcs.go
@@ -9,13 +9,19 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/invopop/jsonschema"
 	"github.com/solo-io/skv2/codegen/model/values"
 	"github.com/solo-io/skv2/codegen/util/stringutils"
+	"google.golang.org/protobuf/types/known/structpb"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/strings/slices"
 
 	"github.com/BurntSushi/toml"
 	"github.com/Masterminds/sprig/v3"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/iancoleman/orderedmap"
 	"github.com/iancoleman/strcase"
 	"github.com/solo-io/skv2/codegen/model"
 	"github.com/solo-io/skv2/codegen/util"
@@ -30,14 +36,15 @@ func makeTemplateFuncs(customFuncs template.FuncMap) template.FuncMap {
 	skv2Funcs := template.FuncMap{
 		// string utils
 
-		"toToml":     toTOML,
-		"toYaml":     toYAML,
-		"fromYaml":   fromYAML,
-		"toJson":     toJSON,
-		"fromJson":   fromJSON,
-		"toNode":     toNode,
-		"fromNode":   fromNode,
-		"mergeNodes": mergeNodes,
+		"toToml":       toTOML,
+		"toYaml":       toYAML,
+		"fromYaml":     fromYAML,
+		"toJson":       toJSON,
+		"fromJson":     fromJSON,
+		"toNode":       toNode,
+		"fromNode":     fromNode,
+		"mergeNodes":   mergeNodes,
+		"toJsonSchema": toJSONSchema,
 
 		"join":            strings.Join,
 		"lower":           strings.ToLower,
@@ -90,6 +97,7 @@ func makeTemplateFuncs(customFuncs template.FuncMap) template.FuncMap {
 			}
 			if o.ValuePath != "" {
 				splitPath := strings.Split(o.ValuePath, ".")
+				reverse(splitPath)
 				for _, p := range splitPath {
 					opValues = map[string]interface{}{
 						strcase.ToLowerCamel(p): opValues,
@@ -107,6 +115,7 @@ func makeTemplateFuncs(customFuncs template.FuncMap) template.FuncMap {
 				}
 				if o.ValuePath != "" {
 					splitPath := strings.Split(o.ValuePath, ".")
+					reverse(splitPath)
 					for _, p := range splitPath {
 						opValues = map[string]interface{}{
 							strcase.ToLowerCamel(p): opValues,
@@ -560,6 +569,339 @@ func fromJSON(str string) map[string]interface{} {
 		m["Error"] = err.Error()
 	}
 	return m
+}
+
+// toJSONSchema generates the json schema for the values of the helm chart
+func toJSONSchema(values values.UserHelmValues) string {
+	reflector := createJsonSchemaReflector(values)
+	schema := new(jsonschema.Schema)
+
+	// add json schema properties from the chart's custom values
+	if values.CustomValues != nil {
+		mergeJsonSchemaProperties(schema, reflector.Reflect(values.CustomValues))
+	}
+
+	// add json schema for the operators
+	if values.Operators != nil {
+		for _, o := range values.Operators {
+			opSchema := jsonSchemaForOperator(reflector, &o)
+			mergeJsonSchemaProperties(schema, opSchema)
+		}
+	}
+
+	jsonSchema, err := schema.MarshalJSON()
+	if err != nil {
+		panic(err)
+	}
+
+	return indentJson(string(jsonSchema))
+}
+
+type customTypeMapper func(reflect.Type, *jsonschema.Schema) *jsonschema.Schema
+
+// createTypeMappings initializes the type mappings based on what the user has
+// passed and also some reasonable defaults
+func createCustomTypeMapper(values values.UserHelmValues) customTypeMapper {
+	// add the default type mappings ... these types have customized json deser
+	// behaviour so we need to have custom mappings describing allowed values
+	typeMappings := map[reflect.Type]customTypeMapper{
+		reflect.TypeOf(structpb.Value{}): func(t reflect.Type, defaultSchema *jsonschema.Schema) *jsonschema.Schema {
+			schema := new(jsonschema.Schema)
+			schema.AnyOf = []*jsonschema.Schema{
+				{Type: "null"},
+				{Type: "number"},
+				{Type: "string"},
+				{Type: "boolean"},
+				{Type: "object"},
+				{Type: "array"},
+			}
+			return schema
+		},
+
+		reflect.TypeOf(metav1.Time{}): func(t reflect.Type, defaultSchema *jsonschema.Schema) *jsonschema.Schema {
+			schema := new(jsonschema.Schema)
+			schema.AnyOf = []*jsonschema.Schema{
+				{
+					Type:   "string",
+					Format: "date-time",
+				},
+				{
+					Type: "null",
+				},
+			}
+			return schema
+		},
+
+		reflect.TypeOf(resource.Quantity{}): func(t reflect.Type, defaultSchema *jsonschema.Schema) *jsonschema.Schema {
+			return &jsonschema.Schema{
+				AnyOf: []*jsonschema.Schema{
+					{Type: "string"},
+					{Type: "number"},
+				},
+			}
+		},
+
+		reflect.TypeOf(v1.SecurityContext{}): func(t reflect.Type, defaultSchema *jsonschema.Schema) *jsonschema.Schema {
+			return &jsonschema.Schema{
+				AnyOf: []*jsonschema.Schema{
+					defaultSchema,
+					{Type: "boolean", Const: false},
+				},
+			}
+		},
+	}
+
+	return func(t reflect.Type, schema *jsonschema.Schema) *jsonschema.Schema {
+		if values.JsonSchema.CustomTypeMapper != nil {
+			// the custom mappings are accept the json schema as a map and are
+			// expected to return an interface that can be serialized as a json schema
+			// or null if it doesn't handle the type
+
+			// serialize default schema into a map
+			var defaultAsMap map[string]interface{}
+			buf, err := schema.MarshalJSON()
+			if err != nil {
+				panic(err)
+			}
+			err = json.Unmarshal(buf, &defaultAsMap)
+			if err != nil {
+				panic(err)
+			}
+
+			// if the type is handled, deserialize it into json schema and return that
+			modifiedSchema := values.JsonSchema.CustomTypeMapper(t, defaultAsMap)
+			if modifiedSchema != nil {
+				buf, err = json.Marshal(modifiedSchema)
+				if err != nil {
+					panic(err)
+				}
+				result := new(jsonschema.Schema)
+				err = result.UnmarshalJSON(buf)
+				if err != nil {
+					panic(err)
+				}
+				return result
+			}
+		}
+
+		defaultTypeMapper, ok := typeMappings[t]
+		if ok {
+			return defaultTypeMapper(t, schema)
+		}
+
+		return nil
+	}
+}
+
+// initialize a new instance of the jsonschema Reflector with configured to
+// create json schema for chart.
+func createJsonSchemaReflector(values values.UserHelmValues) *jsonschema.Reflector {
+	// we might want to pass configuration ot this from values.UserHelmValues
+	// in the future, to control how the schema is generated, but for now just
+	// hard-coding some sensible defaults that won't break existing charts..
+	reflector := jsonschema.Reflector{
+		Anonymous:                  true,
+		AllowAdditionalProperties:  true,
+		DoNotReference:             true,
+		RequiredFromJSONSchemaTags: true,
+	}
+
+	customTypeMapper := createCustomTypeMapper(values)
+	extractBaseMapping := makeBaseMappingExtractor(&reflector)
+
+	// specify custom overrides for some specific types
+	reflector.Mapper = func(t reflect.Type) *jsonschema.Schema {
+		baseMapping := extractBaseMapping(t)
+		if baseMapping == nil {
+			return baseMapping
+		}
+
+		customMapping := customTypeMapper(t, baseMapping)
+		if customMapping != nil {
+			return customMapping
+		}
+
+		// allow maps & arrays to be nil by default, which makes this backwards
+		// compatible with older charts without schemas. In the future, might like
+		// to control this behaviour w/ tags such as `jsonschema:"nullable"`
+		// to fields of the values structs.
+		if t.Kind() == reflect.Map || t.Kind() == reflect.Slice {
+			return wrapAsNullable(baseMapping)
+		}
+
+		// make the pointer fields on structs nullable
+		if t.Kind() == reflect.Struct {
+			return pointerFieldsNullableTransformer(t, customTypeMapper)(baseMapping)
+		}
+
+		// by returning nil, it defaults to the default mapping behaviour reflector
+		return nil
+	}
+
+	return &reflector
+}
+
+type jsonSchemaTransform func(*jsonschema.Schema) *jsonschema.Schema
+
+// makeBaseMappingExtractor allows the base mapping function of the reflector
+// to be called to generate the default json schema for the type (as if the
+// relfector had no custom Mapper)
+func makeBaseMappingExtractor(
+	reflector *jsonschema.Reflector,
+) func(t reflect.Type) *jsonschema.Schema {
+	// we try to map the type recursively by re-calling ReflectFromType & letting
+	// the calling funciton follow the same code path into this function which
+	// will check this flag for the recursion exit condition
+	insideBaseMappingExtractor := false
+
+	return func(t reflect.Type) *jsonschema.Schema {
+		if insideBaseMappingExtractor {
+			insideBaseMappingExtractor = false
+			return nil // deletage to the default mapper & return
+		}
+
+		insideBaseMappingExtractor = true
+
+		// map the type to it's default non-nullable type
+		schema := reflector.ReflectFromType(t)
+
+		// remove default fields
+		schema.Version = ""
+
+		return schema
+	}
+}
+
+// wrapAsNullable wraps the json schema in a way that allows the json value
+// to be null
+func wrapAsNullable(schema *jsonschema.Schema) *jsonschema.Schema {
+	return &jsonschema.Schema{
+		AnyOf: []*jsonschema.Schema{
+			schema,
+			{Type: "null"},
+		},
+	}
+}
+
+// pointerFieldsNullableTransformer creates function that when called will
+// return a json schema with the fields which are pointers on the struct type
+// as nullable
+func pointerFieldsNullableTransformer(
+	t reflect.Type,
+	customTypeMapper customTypeMapper,
+) jsonSchemaTransform {
+	return func(schema *jsonschema.Schema) *jsonschema.Schema {
+		makePointerFieldsNullable(t, schema, customTypeMapper)
+		return schema
+	}
+}
+
+// makePointerFieldsNullableInternal makes any fields that are of type pointer
+// on the passed type (which must be a struct) nullable in the json schema
+func makePointerFieldsNullable(
+	t reflect.Type,
+	schema *jsonschema.Schema,
+	customTypeMapper customTypeMapper,
+) {
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		jsonPropertyName := field.Name
+
+		// check if the type has been renmamed via the json tag
+		if jsonTag, ok := field.Tag.Lookup("json"); ok {
+			jsonTagSegments := strings.Split(jsonTag, ",")
+			jsonPropertyName = jsonTagSegments[0]
+		}
+
+		if field.Type.Kind() == reflect.Pointer {
+			f, ok := schema.Properties.Get(jsonPropertyName)
+			if !ok {
+				continue
+			}
+			fieldSchema := f.(*jsonschema.Schema)
+
+			// if there's a custom type mapping for the field, delegate to that
+			// whether it wants the field to be nullable
+			if customTypeMapper(field.Type.Elem(), fieldSchema) != nil {
+				continue
+			}
+
+			schema.Properties.Set(jsonPropertyName, wrapAsNullable(fieldSchema))
+		}
+	}
+}
+
+// mergeJsonSchemaProperties Adds the properties from the source json schema
+// to the target
+func mergeJsonSchemaProperties(
+	target *jsonschema.Schema,
+	src *jsonschema.Schema,
+) {
+	if target.Properties == nil {
+		target.Properties = orderedmap.New()
+	}
+
+	for _, prop := range src.Properties.Keys() {
+		val, _ := src.Properties.Get(prop)
+		target.Properties.Set(prop, val)
+	}
+}
+
+// jsonSchemaForOperator creates the json schema for the operator's values.
+//
+// The resulting schema will have the values nested at the appropriate path,
+// taking into account the operator's name and value path. This means it can be
+// added directly to the base object's schema
+func jsonSchemaForOperator(
+	reflector *jsonschema.Reflector,
+	o *values.UserOperatorValues,
+) *jsonschema.Schema {
+	schema := reflector.Reflect(o.Values)
+
+	// if the opeartor defines custom values, add the properties to the schema
+	if o.CustomValues != nil {
+		mergeJsonSchemaProperties(schema, reflector.Reflect(o.CustomValues))
+	}
+
+	// nest the operator values schema in the correct place
+	path := []string{strcase.ToLowerCamel(o.Name)}
+	if o.ValuePath != "" {
+		splitPath := strings.Split(o.ValuePath, ".")
+		reverse(splitPath)
+		path = append(splitPath, path...)
+	}
+	schema = nestSchemaAtPath(schema, path...)
+
+	return schema
+}
+
+// returns a new schema, nested within an object at the given path
+func nestSchemaAtPath(schema *jsonschema.Schema, path ...string) *jsonschema.Schema {
+	for _, p := range path {
+		parentSchema := new(jsonschema.Schema)
+		parentSchema.Type = "object"
+		parentSchema.Properties = orderedmap.New()
+		parentSchema.Properties.Set(p, schema)
+		schema = parentSchema
+	}
+
+	return schema
+}
+
+func indentJson(src string) string {
+	var buf bytes.Buffer
+	err := json.Indent(&buf, []byte(src), "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return buf.String()
+}
+
+// reverse mutates a slice of strings to reverse the order.
+func reverse(s []string) {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
 }
 
 func splitTrimEmpty(s, sep string) []string {

--- a/codegen/render/funcs.go
+++ b/codegen/render/funcs.go
@@ -575,7 +575,7 @@ func fromJSON(str string) map[string]interface{} {
 func toJSONSchema(values values.UserHelmValues) string {
 	reflector := createJsonSchemaReflector(values)
 	schema := new(jsonschema.Schema)
-	schema.Version = "https://json-schema.org/draft/2020-12/schema"
+	schema.Version = jsonschema.Version
 
 	// add json schema properties from the chart's custom values
 	if values.CustomValues != nil {

--- a/codegen/render/funcs.go
+++ b/codegen/render/funcs.go
@@ -697,7 +697,7 @@ func createCustomTypeMapper(values values.UserHelmValues) customTypeMapper {
 // initialize a new instance of the jsonschema Reflector with configured to
 // create json schema for chart.
 func createJsonSchemaReflector(values values.UserHelmValues) *jsonschema.Reflector {
-	// we might want to pass configuration ot this from values.UserHelmValues
+	// we might want to pass configuration of this from values.UserHelmValues
 	// in the future, to control how the schema is generated, but for now just
 	// hard-coding some sensible defaults that won't break existing charts..
 	reflector := jsonschema.Reflector{

--- a/codegen/render/funcs_test.go
+++ b/codegen/render/funcs_test.go
@@ -2,8 +2,8 @@ package render_test
 
 import (
 	"encoding/json"
-	"reflect"
 	"fmt"
+	"reflect"
 	"strings"
 
 	structpb "github.com/golang/protobuf/ptypes/struct"

--- a/codegen/render/funcs_test.go
+++ b/codegen/render/funcs_test.go
@@ -1,23 +1,30 @@
 package render_test
 
 import (
+	"encoding/json"
+	"reflect"
 	"strings"
 
+	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/lithammer/dedent"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/solo-io/skv2/codegen/model/values"
 	"github.com/solo-io/skv2/codegen/render"
 )
 
+func prepareExpected(expected string) string {
+	expected = strings.Trim(expected, "\n")
+	expected = dedent.Dedent(expected)
+	expected = strings.ReplaceAll(expected, "\t", "  ")
+	return expected
+}
+
 var _ = Describe("toYAMLWithComments", func() {
-	prepareExpected := func(expected string) string {
-		expected = strings.Trim(expected, "\n")
-		expected = dedent.Dedent(expected)
-		expected = strings.ReplaceAll(expected, "\t", "  ")
-		return expected
-	}
 
 	It("decodes yaml with the comments", func() {
 		type NestedType struct {
@@ -273,5 +280,385 @@ var _ = Describe("toYAMLWithComments", func() {
 		Expect(render.FromNode(node)).To(Equal(prepareExpected(`
 			Field1: one
 		`)))
+	})
+})
+
+var _ = Describe("toJSONSchema", func() {
+	It("creates a schema for an object with properties from custom values and operators", func() {
+		type Type1 struct {
+			Field1a string `json:"field1a"`
+		}
+
+		type Type2 struct {
+			Field2a string `json:"field2a"`
+		}
+
+		result := render.ToJSONSchema(values.UserHelmValues{
+			CustomValues: &Type1{
+				Field1a: "Hello",
+			},
+			Operators: []values.UserOperatorValues{
+				{
+					Name:         "operator1",
+					Values:       values.UserValues{},
+					CustomValues: &Type2{Field2a: "hello2"},
+				},
+				{
+					Name:         "My_Operator_Two",
+					ValuePath:    "my.values",
+					Values:       values.UserValues{},
+					CustomValues: &Type2{Field2a: "hello2"},
+				},
+			},
+		})
+
+		resultContainer := struct {
+			Properties *struct {
+				Field1a   map[string]interface{} `json:"field1a"`
+				Operator1 *struct {
+					Properties map[string]map[string]interface{}
+				} `json:"operator1"`
+				Operator2 *struct {
+					Properties *struct {
+						My *struct {
+							Properties *struct {
+								Values *struct {
+									Properties map[string]map[string]interface{} `json:"properties"`
+								} `json:"values"`
+							} `json:"properties"`
+						} `json:"my"`
+					} `json:"properties"`
+				} `json:"myOperatorTwo"`
+			} `json:"properties"`
+		}{}
+
+		checkHasStandardValuesFields := func(valueProperties map[string]map[string]interface{}) {
+			Expect(valueProperties["image"]["type"]).To(Equal("object"))
+			Expect(valueProperties["enabled"]["type"]).To(Equal("boolean"))
+			Expect(valueProperties["runAsUser"]["type"]).To(Equal("integer"))
+		}
+
+		Expect(json.Unmarshal([]byte(result), &resultContainer)).NotTo(HaveOccurred())
+
+		Expect(resultContainer.Properties).NotTo(BeNil())
+		Expect(resultContainer.Properties.Field1a).NotTo(BeNil())
+		Expect(resultContainer.Properties.Field1a["type"]).To(Equal("string"))
+
+		Expect(resultContainer.Properties.Operator1).NotTo(BeNil())
+		Expect(resultContainer.Properties.Operator1.Properties).NotTo(BeNil())
+		Expect(resultContainer.Properties.Operator1.Properties["field2a"]["type"]).To(Equal("string"))
+		checkHasStandardValuesFields(resultContainer.Properties.Operator1.Properties)
+
+		Expect(resultContainer.Properties.Operator2).NotTo(BeNil())
+		Expect(resultContainer.Properties.Operator2.Properties).NotTo(BeNil())
+		Expect(resultContainer.Properties.Operator2.Properties.My).NotTo(BeNil())
+		Expect(resultContainer.Properties.Operator2.Properties.My.Properties).NotTo(BeNil())
+		Expect(resultContainer.Properties.Operator2.Properties.My.Properties.Values).NotTo(BeNil())
+		Expect(resultContainer.Properties.Operator2.Properties.My.Properties.Values.Properties["field2a"]["type"]).To(Equal("string"))
+		checkHasStandardValuesFields(resultContainer.Properties.Operator2.Properties.My.Properties.Values.Properties)
+	})
+
+	It("adds some json schema behaviour based on the jsonschema tags", func() {
+		type Type1 struct {
+			Field1a string `json:"field1a" jsonschema:"title=field a,description=the field called a,example=aaa,example=bbb,default=a"`
+		}
+		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
+		expected := prepareExpected(`
+			{
+				"properties": {
+					"field1a": {
+						"type": "string",
+						"title": "field a",
+						"description": "the field called a",
+						"default": "a",
+						"examples": [
+							"aaa",
+							"bbb"
+						]
+					}
+				}
+			}`)
+		Expect(result).To(Equal(expected))
+	})
+
+	It("will correctly generate schema for types that should be nullable", func() {
+		type Type1 struct {
+			Field1 map[string]interface{}
+			Field2 []*struct {
+				Field3 string
+			}
+		}
+
+		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
+		expected := prepareExpected(`
+			{
+				"properties": {
+					"Field1": {
+						"anyOf": [
+							{
+								"type": "object"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"Field2": {
+						"anyOf": [
+							{
+								"items": {
+									"properties": {
+										"Field3": {
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"type": "array"
+							},
+							{
+								"type": "null"
+							}
+						]
+					}
+				}
+			}`)
+		Expect(result).To(Equal(expected))
+	})
+
+	It("handles nullable struct fields correctly", func() {
+		type Type1 struct {
+		}
+		type Type2 struct {
+			Field2A *Type1 // should be nullable
+			Field2B *Type1 `json:"field2_b"` // check it handles renamed fields as well
+		}
+
+		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type2{}})
+		expected := prepareExpected(`
+			{
+				"properties": {
+					"Field2A": {
+						"anyOf": [
+							{
+								"properties": {},
+								"type": "object"
+							},
+							{
+								"type": "null"
+							}
+						]
+					},
+					"field2_b": {
+						"anyOf": [
+							{
+								"properties": {},
+								"type": "object"
+							},
+							{
+								"type": "null"
+							}
+						]
+					}
+				}
+			}`)
+		Expect(expected).To(Equal(result))
+	})
+
+	It("will allow pbstructs to be deserialized as anything", func() {
+		type Type1 struct {
+			Field1 *structpb.Value
+		}
+		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
+		expected := prepareExpected(`
+			{
+				"properties": {
+					"Field1": {
+						"anyOf": [
+							{
+								"type": "null"
+							},
+							{
+								"type": "number"
+							},
+							{
+								"type": "string"
+							},
+							{
+								"type": "boolean"
+							},
+							{
+								"type": "object"
+							},
+							{
+								"type": "array"
+							}
+						]
+					}
+				}
+			}`)
+		Expect(result).To(Equal(expected))
+	})
+
+	It("maps time as a nullable string", func() {
+		type Type1 struct {
+			Field1 metav1.Time `json:"metatime"`
+		}
+		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
+		expected := prepareExpected(`
+			{
+				"properties": {
+					"metatime": {
+						"anyOf": [
+							{
+								"type": "string",
+								"format": "date-time"
+							},
+							{
+								"type": "null"
+							}
+						]
+					}
+				}
+			}`)
+		Expect(result).To(Equal(expected))
+	})
+
+	It("maps resource quantity as either a string or number", func() {
+		type Type1 struct {
+			Field1 resource.Quantity
+		}
+		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
+		expected := prepareExpected(`
+			{
+				"properties": {
+					"Field1": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number"
+							}
+						]
+					}
+				}
+			}`)
+		Expect(result).To(Equal(expected))
+	})
+
+	It("maps security context as something that can be mapped to a boolean", func() {
+		type Type1 struct {
+			Field1 *v1.SecurityContext
+		}
+		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
+		resultContainer := struct {
+			Properties struct {
+				Field1 *struct {
+					AnyOf []*struct {
+						Const interface{} `json:"const"`
+						Type  string      `json:"type"`
+					} `json:"anyOf"`
+				}
+			} `json:"properties"`
+		}{}
+		Expect(json.Unmarshal([]byte(result), &resultContainer)).NotTo(HaveOccurred())
+		Expect(resultContainer.Properties.Field1).NotTo(BeNil())
+		Expect(resultContainer.Properties.Field1).NotTo(BeNil())
+		Expect(resultContainer.Properties.Field1.AnyOf).NotTo(BeNil())
+		Expect(resultContainer.Properties.Field1.AnyOf).To(HaveLen(2))
+		Expect(resultContainer.Properties.Field1.AnyOf[0].Type).To(Equal("object"))
+		Expect(resultContainer.Properties.Field1.AnyOf[1].Type).To(Equal("boolean"))
+		Expect(resultContainer.Properties.Field1.AnyOf[1].Const).To(BeFalse())
+	})
+
+	Context("custom type mappings", func() {
+		type MyJsonSchemaType struct {
+			Type  string `json:"type"`
+			AnyOf []interface{}
+		}
+
+		It("will invoke custom json schema type mappings", func() {
+			type Type1 struct{}
+			type Type2 struct {
+				FieldA Type1
+			}
+
+			mapAsNumber := func(map[string]interface{}) interface{} {
+				return &MyJsonSchemaType{
+					Type: "number",
+				}
+			}
+
+			typeMapper := func(t reflect.Type, s map[string]interface{}) interface{} {
+				if t == reflect.TypeOf(Type1{}) {
+					return mapAsNumber(s)
+				}
+				return nil
+			}
+
+			result := render.ToJSONSchema(values.UserHelmValues{
+				CustomValues: &Type2{},
+				JsonSchema: values.UserJsonSchema{
+					CustomTypeMapper: typeMapper,
+				},
+			})
+			expected := prepareExpected(`
+				{
+					"properties": {
+						"FieldA": {
+							"type": "number"
+						}
+					}
+				}`)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("allows performing modification of the original type", func() {
+			type Type1 struct{}
+			type Type2 struct {
+				FieldA Type1
+			}
+
+			mapAsPossiblyBoolean := func(original map[string]interface{}) interface{} {
+				return MyJsonSchemaType{
+					AnyOf: []interface{}{
+						original,
+						&MyJsonSchemaType{Type: "boolean"},
+					},
+				}
+			}
+
+			typeMapper := func(t reflect.Type, s map[string]interface{}) interface{} {
+				if t == reflect.TypeOf(Type1{}) {
+					return mapAsPossiblyBoolean(s)
+				}
+				return nil
+			}
+
+			result := render.ToJSONSchema(values.UserHelmValues{
+				CustomValues: &Type2{},
+				JsonSchema: values.UserJsonSchema{
+					CustomTypeMapper: typeMapper,
+				},
+			})
+			expected := prepareExpected(`
+				{
+					"properties": {
+						"FieldA": {
+							"anyOf": [
+								{
+									"properties": {},
+									"type": "object"
+								},
+								{
+									"type": "boolean"
+								}
+							]
+						}
+					}
+				}`)
+			Expect(result).To(Equal(expected))
+		})
 	})
 })

--- a/codegen/render/funcs_test.go
+++ b/codegen/render/funcs_test.go
@@ -365,6 +365,7 @@ var _ = Describe("toJSONSchema", func() {
 		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
 		expected := prepareExpected(`
 			{
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
 				"properties": {
 					"field1a": {
 						"type": "string",
@@ -392,6 +393,7 @@ var _ = Describe("toJSONSchema", func() {
 		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
 		expected := prepareExpected(`
 			{
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
 				"properties": {
 					"Field1": {
 						"anyOf": [
@@ -437,6 +439,7 @@ var _ = Describe("toJSONSchema", func() {
 		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type2{}})
 		expected := prepareExpected(`
 			{
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
 				"properties": {
 					"Field2A": {
 						"anyOf": [
@@ -472,6 +475,7 @@ var _ = Describe("toJSONSchema", func() {
 		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
 		expected := prepareExpected(`
 			{
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
 				"properties": {
 					"Field1": {
 						"anyOf": [
@@ -507,6 +511,7 @@ var _ = Describe("toJSONSchema", func() {
 		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
 		expected := prepareExpected(`
 			{
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
 				"properties": {
 					"metatime": {
 						"anyOf": [
@@ -531,6 +536,7 @@ var _ = Describe("toJSONSchema", func() {
 		result := render.ToJSONSchema(values.UserHelmValues{CustomValues: &Type1{}})
 		expected := prepareExpected(`
 			{
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
 				"properties": {
 					"Field1": {
 						"anyOf": [
@@ -605,6 +611,7 @@ var _ = Describe("toJSONSchema", func() {
 			})
 			expected := prepareExpected(`
 				{
+					"$schema": "https://json-schema.org/draft/2020-12/schema",
 					"properties": {
 						"FieldA": {
 							"type": "number"
@@ -644,6 +651,7 @@ var _ = Describe("toJSONSchema", func() {
 			})
 			expected := prepareExpected(`
 				{
+					"$schema": "https://json-schema.org/draft/2020-12/schema",
 					"properties": {
 						"FieldA": {
 							"anyOf": [

--- a/codegen/render/render.go
+++ b/codegen/render/render.go
@@ -17,8 +17,7 @@ type HeaderOverride interface {
 }
 
 type OutFile struct {
-	Path           string
-	Permission     os.FileMode
-	Content        string         // set by Renderer
-	HeaderOverride HeaderOverride // overrides the defauld the default header of the outfile writer
+	Path       string
+	Permission os.FileMode
+	Content    string // set by Renderer
 }

--- a/codegen/render/render.go
+++ b/codegen/render/render.go
@@ -12,8 +12,13 @@ type Resource = model.Resource
 
 type Field = model.Field
 
+type HeaderOverride interface {
+	Generate() string
+}
+
 type OutFile struct {
-	Path       string
-	Permission os.FileMode
-	Content    string // set by Renderer
+	Path           string
+	Permission     os.FileMode
+	Content        string         // set by Renderer
+	HeaderOverride HeaderOverride // overrides the defauld the default header of the outfile writer
 }

--- a/codegen/templates/chart/values.schema.jsontmpl
+++ b/codegen/templates/chart/values.schema.jsontmpl
@@ -1,0 +1,2 @@
+[[- $values := .BuildChartValues -]]
+[[- toJsonSchema $values -]]

--- a/codegen/test/chart-no-desc/values.schema.json
+++ b/codegen/test/chart-no-desc/values.schema.json
@@ -1,0 +1,8816 @@
+{
+  "properties": {
+    "painter": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "image": {
+          "properties": {
+            "tag": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "registry": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "pullSecret": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "env": {
+          "anyOf": [
+            {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "fieldRef": {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "fieldPath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "resourceFieldRef": {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "containerName": {
+                                    "type": "string"
+                                  },
+                                  "resource": {
+                                    "type": "string"
+                                  },
+                                  "divisor": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "configMapKeyRef": {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "anyOf": [
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "secretKeyRef": {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "anyOf": [
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resources": {
+          "properties": {
+            "limits": {
+              "anyOf": [
+                {
+                  "patternProperties": {
+                    ".*": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "requests": {
+              "anyOf": [
+                {
+                  "patternProperties": {
+                    ".*": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "securityContext": {
+          "anyOf": [
+            {
+              "properties": {
+                "capabilities": {
+                  "properties": {
+                    "add": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "drop": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "privileged": {
+                  "type": "boolean"
+                },
+                "seLinuxOptions": {
+                  "properties": {
+                    "user": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "level": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "windowsOptions": {
+                  "properties": {
+                    "gmsaCredentialSpecName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "gmsaCredentialSpec": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "runAsUserName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "hostProcess": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "runAsUser": {
+                  "type": "integer"
+                },
+                "runAsGroup": {
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean"
+                },
+                "readOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "allowPrivilegeEscalation": {
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "type": "string"
+                },
+                "seccompProfile": {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "localhostProfile": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "boolean",
+              "const": false
+            }
+          ]
+        },
+        "sidecars": {
+          "anyOf": [
+            {
+              "patternProperties": {
+                ".*": {
+                  "properties": {
+                    "image": {
+                      "properties": {
+                        "tag": {
+                          "type": "string"
+                        },
+                        "repository": {
+                          "type": "string"
+                        },
+                        "registry": {
+                          "type": "string"
+                        },
+                        "pullPolicy": {
+                          "type": "string"
+                        },
+                        "pullSecret": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "env": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "valueFrom": {
+                                "anyOf": [
+                                  {
+                                    "properties": {
+                                      "fieldRef": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "apiVersion": {
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "resourceFieldRef": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "containerName": {
+                                                "type": "string"
+                                              },
+                                              "resource": {
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "configMapKeyRef": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "secretKeyRef": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "resources": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "limits": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "requests": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "securityContext": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "capabilities": {
+                              "properties": {
+                                "add": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "drop": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "privileged": {
+                              "type": "boolean"
+                            },
+                            "seLinuxOptions": {
+                              "properties": {
+                                "user": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "level": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "windowsOptions": {
+                              "properties": {
+                                "gmsaCredentialSpecName": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "gmsaCredentialSpec": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "runAsUserName": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "hostProcess": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "runAsUser": {
+                              "type": "integer"
+                            },
+                            "runAsGroup": {
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "type": "boolean"
+                            },
+                            "readOnlyRootFilesystem": {
+                              "type": "boolean"
+                            },
+                            "allowPrivilegeEscalation": {
+                              "type": "boolean"
+                            },
+                            "procMount": {
+                              "type": "string"
+                            },
+                            "seccompProfile": {
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "localhostProfile": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "boolean",
+                          "const": false
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "floatingUserId": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "integer"
+        },
+        "serviceType": {
+          "type": "string"
+        },
+        "ports": {
+          "anyOf": [
+            {
+              "patternProperties": {
+                ".*": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "deploymentOverrides": {
+          "anyOf": [
+            {
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "apiVersion": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "creationTimestamp": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deletionTimestamp": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "labels": {
+                      "anyOf": [
+                        {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "annotations": {
+                      "anyOf": [
+                        {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "ownerReferences": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              },
+                              "controller": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "blockOwnerDeletion": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "finalizers": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "managedFields": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "anyOf": [
+                                  {
+                                    "properties": {},
+                                    "type": "object"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "subresource": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "spec": {
+                  "properties": {
+                    "replicas": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "selector": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "matchLabels": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "matchExpressions": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "template": {
+                      "properties": {
+                        "metadata": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "generateName": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            },
+                            "selfLink": {
+                              "type": "string"
+                            },
+                            "uid": {
+                              "type": "string"
+                            },
+                            "resourceVersion": {
+                              "type": "string"
+                            },
+                            "generation": {
+                              "type": "integer"
+                            },
+                            "creationTimestamp": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "deletionTimestamp": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "deletionGracePeriodSeconds": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "labels": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "annotations": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "ownerReferences": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "apiVersion": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      },
+                                      "controller": {
+                                        "anyOf": [
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "blockOwnerDeletion": {
+                                        "anyOf": [
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "finalizers": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "managedFields": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "manager": {
+                                        "type": "string"
+                                      },
+                                      "operation": {
+                                        "type": "string"
+                                      },
+                                      "apiVersion": {
+                                        "type": "string"
+                                      },
+                                      "time": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "fieldsType": {
+                                        "type": "string"
+                                      },
+                                      "fieldsV1": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {},
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "subresource": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "spec": {
+                          "properties": {
+                            "volumes": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "hostPath": {
+                                        "properties": {
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "emptyDir": {
+                                        "properties": {
+                                          "medium": {
+                                            "type": "string"
+                                          },
+                                          "sizeLimit": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcePersistentDisk": {
+                                        "properties": {
+                                          "pdName": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "partition": {
+                                            "type": "integer"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "awsElasticBlockStore": {
+                                        "properties": {
+                                          "volumeID": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "partition": {
+                                            "type": "integer"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gitRepo": {
+                                        "properties": {
+                                          "repository": {
+                                            "type": "string"
+                                          },
+                                          "revision": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "secret": {
+                                        "properties": {
+                                          "secretName": {
+                                            "type": "string"
+                                          },
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "mode": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "defaultMode": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "optional": {
+                                            "anyOf": [
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "nfs": {
+                                        "properties": {
+                                          "server": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "iscsi": {
+                                        "properties": {
+                                          "targetPortal": {
+                                            "type": "string"
+                                          },
+                                          "iqn": {
+                                            "type": "string"
+                                          },
+                                          "lun": {
+                                            "type": "integer"
+                                          },
+                                          "iscsiInterface": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "portals": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "chapAuthDiscovery": {
+                                            "type": "boolean"
+                                          },
+                                          "chapAuthSession": {
+                                            "type": "boolean"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "initiatorName": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "glusterfs": {
+                                        "properties": {
+                                          "endpoints": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "persistentVolumeClaim": {
+                                        "properties": {
+                                          "claimName": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "rbd": {
+                                        "properties": {
+                                          "monitors": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "image": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "pool": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          },
+                                          "keyring": {
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "flexVolume": {
+                                        "properties": {
+                                          "driver": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "options": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "cinder": {
+                                        "properties": {
+                                          "volumeID": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "cephfs": {
+                                        "properties": {
+                                          "monitors": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          },
+                                          "secretFile": {
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "flocker": {
+                                        "properties": {
+                                          "datasetName": {
+                                            "type": "string"
+                                          },
+                                          "datasetUUID": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "downwardAPI": {
+                                        "properties": {
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "properties": {
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldRef": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "apiVersion": {
+                                                              "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "resourceFieldRef": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "containerName": {
+                                                              "type": "string"
+                                                            },
+                                                            "resource": {
+                                                              "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "mode": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "defaultMode": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "fc": {
+                                        "properties": {
+                                          "targetWWNs": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "lun": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "wwids": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "azureFile": {
+                                        "properties": {
+                                          "secretName": {
+                                            "type": "string"
+                                          },
+                                          "shareName": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "configMap": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "mode": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "defaultMode": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "optional": {
+                                            "anyOf": [
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "vsphereVolume": {
+                                        "properties": {
+                                          "volumePath": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "storagePolicyName": {
+                                            "type": "string"
+                                          },
+                                          "storagePolicyID": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "quobyte": {
+                                        "properties": {
+                                          "registry": {
+                                            "type": "string"
+                                          },
+                                          "volume": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          },
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "tenant": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "azureDisk": {
+                                        "properties": {
+                                          "diskName": {
+                                            "type": "string"
+                                          },
+                                          "diskURI": {
+                                            "type": "string"
+                                          },
+                                          "cachingMode": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "fsType": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "readOnly": {
+                                            "anyOf": [
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "kind": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "photonPersistentDisk": {
+                                        "properties": {
+                                          "pdID": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "projected": {
+                                        "properties": {
+                                          "sources": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "properties": {
+                                                    "secret": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "items": {
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "path": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "mode": {
+                                                                        "anyOf": [
+                                                                          {
+                                                                            "type": "integer"
+                                                                          },
+                                                                          {
+                                                                            "type": "null"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            },
+                                                            "optional": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "downwardAPI": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "items": {
+                                                                    "properties": {
+                                                                      "path": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "fieldRef": {
+                                                                        "anyOf": [
+                                                                          {
+                                                                            "properties": {
+                                                                              "apiVersion": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "fieldPath": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object"
+                                                                          },
+                                                                          {
+                                                                            "type": "null"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      "resourceFieldRef": {
+                                                                        "anyOf": [
+                                                                          {
+                                                                            "properties": {
+                                                                              "containerName": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "resource": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "divisor": {
+                                                                                "anyOf": [
+                                                                                  {
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "number"
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            },
+                                                                            "type": "object"
+                                                                          },
+                                                                          {
+                                                                            "type": "null"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      "mode": {
+                                                                        "anyOf": [
+                                                                          {
+                                                                            "type": "integer"
+                                                                          },
+                                                                          {
+                                                                            "type": "null"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "configMap": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "items": {
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "path": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "mode": {
+                                                                        "anyOf": [
+                                                                          {
+                                                                            "type": "integer"
+                                                                          },
+                                                                          {
+                                                                            "type": "null"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            },
+                                                            "optional": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "serviceAccountToken": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "audience": {
+                                                              "type": "string"
+                                                            },
+                                                            "expirationSeconds": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "integer"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            },
+                                                            "path": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "defaultMode": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "portworxVolume": {
+                                        "properties": {
+                                          "volumeID": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "scaleIO": {
+                                        "properties": {
+                                          "gateway": {
+                                            "type": "string"
+                                          },
+                                          "system": {
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "sslEnabled": {
+                                            "type": "boolean"
+                                          },
+                                          "protectionDomain": {
+                                            "type": "string"
+                                          },
+                                          "storagePool": {
+                                            "type": "string"
+                                          },
+                                          "storageMode": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "storageos": {
+                                        "properties": {
+                                          "volumeName": {
+                                            "type": "string"
+                                          },
+                                          "volumeNamespace": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "csi": {
+                                        "properties": {
+                                          "driver": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "anyOf": [
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "fsType": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "volumeAttributes": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "nodePublishSecretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "ephemeral": {
+                                        "properties": {
+                                          "volumeClaimTemplate": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "metadata": {
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "generateName": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "selfLink": {
+                                                        "type": "string"
+                                                      },
+                                                      "uid": {
+                                                        "type": "string"
+                                                      },
+                                                      "resourceVersion": {
+                                                        "type": "string"
+                                                      },
+                                                      "generation": {
+                                                        "type": "integer"
+                                                      },
+                                                      "creationTimestamp": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string",
+                                                            "format": "date-time"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "deletionTimestamp": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string",
+                                                            "format": "date-time"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "deletionGracePeriodSeconds": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "labels": {
+                                                        "anyOf": [
+                                                          {
+                                                            "patternProperties": {
+                                                              ".*": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "annotations": {
+                                                        "anyOf": [
+                                                          {
+                                                            "patternProperties": {
+                                                              ".*": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "ownerReferences": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "properties": {
+                                                                "apiVersion": {
+                                                                  "type": "string"
+                                                                },
+                                                                "kind": {
+                                                                  "type": "string"
+                                                                },
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "uid": {
+                                                                  "type": "string"
+                                                                },
+                                                                "controller": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "blockOwnerDeletion": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "finalizers": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "managedFields": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "properties": {
+                                                                "manager": {
+                                                                  "type": "string"
+                                                                },
+                                                                "operation": {
+                                                                  "type": "string"
+                                                                },
+                                                                "apiVersion": {
+                                                                  "type": "string"
+                                                                },
+                                                                "time": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string",
+                                                                      "format": "date-time"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "fieldsType": {
+                                                                  "type": "string"
+                                                                },
+                                                                "fieldsV1": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "properties": {},
+                                                                      "type": "object"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "subresource": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "spec": {
+                                                    "properties": {
+                                                      "accessModes": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "selector": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "matchLabels": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "patternProperties": {
+                                                                      ".*": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "resources": {
+                                                        "properties": {
+                                                          "limits": {
+                                                            "anyOf": [
+                                                              {
+                                                                "patternProperties": {
+                                                                  ".*": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "type": "string"
+                                                                      },
+                                                                      {
+                                                                        "type": "number"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "requests": {
+                                                            "anyOf": [
+                                                              {
+                                                                "patternProperties": {
+                                                                  ".*": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "type": "string"
+                                                                      },
+                                                                      {
+                                                                        "type": "number"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      },
+                                                      "storageClassName": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "volumeMode": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataSource": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "apiGroup": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataSourceRef": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "apiGroup": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "initContainers": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "image": {
+                                        "type": "string"
+                                      },
+                                      "command": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "args": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "workingDir": {
+                                        "type": "string"
+                                      },
+                                      "ports": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "hostPort": {
+                                                  "type": "integer"
+                                                },
+                                                "containerPort": {
+                                                  "type": "integer"
+                                                },
+                                                "protocol": {
+                                                  "type": "string"
+                                                },
+                                                "hostIP": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "envFrom": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "prefix": {
+                                                  "type": "string"
+                                                },
+                                                "configMapRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "secretRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "env": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                },
+                                                "valueFrom": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "fieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "apiVersion": {
+                                                                  "type": "string"
+                                                                },
+                                                                "fieldPath": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "resourceFieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "containerName": {
+                                                                  "type": "string"
+                                                                },
+                                                                "resource": {
+                                                                  "type": "string"
+                                                                },
+                                                                "divisor": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "configMapKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "secretKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "requests": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "volumeMounts": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "readOnly": {
+                                                  "type": "boolean"
+                                                },
+                                                "mountPath": {
+                                                  "type": "string"
+                                                },
+                                                "subPath": {
+                                                  "type": "string"
+                                                },
+                                                "mountPropagation": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "subPathExpr": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "volumeDevices": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "devicePath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "livenessProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "readinessProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "startupProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "lifecycle": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "postStart": {
+                                                "anyOf": [
+                                                  {
+                                                    "properties": {
+                                                      "exec": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "command": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "httpGet": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "path": {
+                                                                "type": "string"
+                                                              },
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              },
+                                                              "scheme": {
+                                                                "type": "string"
+                                                              },
+                                                              "httpHeaders": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "name": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "tcpSocket": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "preStop": {
+                                                "anyOf": [
+                                                  {
+                                                    "properties": {
+                                                      "exec": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "command": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "httpGet": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "path": {
+                                                                "type": "string"
+                                                              },
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              },
+                                                              "scheme": {
+                                                                "type": "string"
+                                                              },
+                                                              "httpHeaders": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "name": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "tcpSocket": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "terminationMessagePath": {
+                                        "type": "string"
+                                      },
+                                      "terminationMessagePolicy": {
+                                        "type": "string"
+                                      },
+                                      "imagePullPolicy": {
+                                        "type": "string"
+                                      },
+                                      "securityContext": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "capabilities": {
+                                                "properties": {
+                                                  "add": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "drop": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "privileged": {
+                                                "type": "boolean"
+                                              },
+                                              "seLinuxOptions": {
+                                                "properties": {
+                                                  "user": {
+                                                    "type": "string"
+                                                  },
+                                                  "role": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "level": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "windowsOptions": {
+                                                "properties": {
+                                                  "gmsaCredentialSpecName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "gmsaCredentialSpec": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "runAsUserName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "hostProcess": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "runAsUser": {
+                                                "type": "integer"
+                                              },
+                                              "runAsGroup": {
+                                                "type": "integer"
+                                              },
+                                              "runAsNonRoot": {
+                                                "type": "boolean"
+                                              },
+                                              "readOnlyRootFilesystem": {
+                                                "type": "boolean"
+                                              },
+                                              "allowPrivilegeEscalation": {
+                                                "type": "boolean"
+                                              },
+                                              "procMount": {
+                                                "type": "string"
+                                              },
+                                              "seccompProfile": {
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "localhostProfile": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "const": false
+                                          }
+                                        ]
+                                      },
+                                      "stdin": {
+                                        "type": "boolean"
+                                      },
+                                      "stdinOnce": {
+                                        "type": "boolean"
+                                      },
+                                      "tty": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "containers": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "image": {
+                                        "type": "string"
+                                      },
+                                      "command": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "args": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "workingDir": {
+                                        "type": "string"
+                                      },
+                                      "ports": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "hostPort": {
+                                                  "type": "integer"
+                                                },
+                                                "containerPort": {
+                                                  "type": "integer"
+                                                },
+                                                "protocol": {
+                                                  "type": "string"
+                                                },
+                                                "hostIP": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "envFrom": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "prefix": {
+                                                  "type": "string"
+                                                },
+                                                "configMapRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "secretRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "env": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                },
+                                                "valueFrom": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "fieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "apiVersion": {
+                                                                  "type": "string"
+                                                                },
+                                                                "fieldPath": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "resourceFieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "containerName": {
+                                                                  "type": "string"
+                                                                },
+                                                                "resource": {
+                                                                  "type": "string"
+                                                                },
+                                                                "divisor": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "configMapKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "secretKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "requests": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "volumeMounts": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "readOnly": {
+                                                  "type": "boolean"
+                                                },
+                                                "mountPath": {
+                                                  "type": "string"
+                                                },
+                                                "subPath": {
+                                                  "type": "string"
+                                                },
+                                                "mountPropagation": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "subPathExpr": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "volumeDevices": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "devicePath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "livenessProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "readinessProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "startupProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "lifecycle": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "postStart": {
+                                                "anyOf": [
+                                                  {
+                                                    "properties": {
+                                                      "exec": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "command": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "httpGet": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "path": {
+                                                                "type": "string"
+                                                              },
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              },
+                                                              "scheme": {
+                                                                "type": "string"
+                                                              },
+                                                              "httpHeaders": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "name": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "tcpSocket": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "preStop": {
+                                                "anyOf": [
+                                                  {
+                                                    "properties": {
+                                                      "exec": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "command": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "httpGet": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "path": {
+                                                                "type": "string"
+                                                              },
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              },
+                                                              "scheme": {
+                                                                "type": "string"
+                                                              },
+                                                              "httpHeaders": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "name": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "tcpSocket": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "terminationMessagePath": {
+                                        "type": "string"
+                                      },
+                                      "terminationMessagePolicy": {
+                                        "type": "string"
+                                      },
+                                      "imagePullPolicy": {
+                                        "type": "string"
+                                      },
+                                      "securityContext": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "capabilities": {
+                                                "properties": {
+                                                  "add": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "drop": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "privileged": {
+                                                "type": "boolean"
+                                              },
+                                              "seLinuxOptions": {
+                                                "properties": {
+                                                  "user": {
+                                                    "type": "string"
+                                                  },
+                                                  "role": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "level": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "windowsOptions": {
+                                                "properties": {
+                                                  "gmsaCredentialSpecName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "gmsaCredentialSpec": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "runAsUserName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "hostProcess": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "runAsUser": {
+                                                "type": "integer"
+                                              },
+                                              "runAsGroup": {
+                                                "type": "integer"
+                                              },
+                                              "runAsNonRoot": {
+                                                "type": "boolean"
+                                              },
+                                              "readOnlyRootFilesystem": {
+                                                "type": "boolean"
+                                              },
+                                              "allowPrivilegeEscalation": {
+                                                "type": "boolean"
+                                              },
+                                              "procMount": {
+                                                "type": "string"
+                                              },
+                                              "seccompProfile": {
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "localhostProfile": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "const": false
+                                          }
+                                        ]
+                                      },
+                                      "stdin": {
+                                        "type": "boolean"
+                                      },
+                                      "stdinOnce": {
+                                        "type": "boolean"
+                                      },
+                                      "tty": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "ephemeralContainers": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "image": {
+                                        "type": "string"
+                                      },
+                                      "command": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "args": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "workingDir": {
+                                        "type": "string"
+                                      },
+                                      "ports": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "hostPort": {
+                                                  "type": "integer"
+                                                },
+                                                "containerPort": {
+                                                  "type": "integer"
+                                                },
+                                                "protocol": {
+                                                  "type": "string"
+                                                },
+                                                "hostIP": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "envFrom": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "prefix": {
+                                                  "type": "string"
+                                                },
+                                                "configMapRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "secretRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "env": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                },
+                                                "valueFrom": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "fieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "apiVersion": {
+                                                                  "type": "string"
+                                                                },
+                                                                "fieldPath": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "resourceFieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "containerName": {
+                                                                  "type": "string"
+                                                                },
+                                                                "resource": {
+                                                                  "type": "string"
+                                                                },
+                                                                "divisor": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "configMapKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "secretKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "requests": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "volumeMounts": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "readOnly": {
+                                                  "type": "boolean"
+                                                },
+                                                "mountPath": {
+                                                  "type": "string"
+                                                },
+                                                "subPath": {
+                                                  "type": "string"
+                                                },
+                                                "mountPropagation": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "subPathExpr": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "volumeDevices": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "devicePath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "livenessProbe": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "grpc": {
+                                            "properties": {
+                                              "port": {
+                                                "type": "integer"
+                                              },
+                                              "service": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "initialDelaySeconds": {
+                                            "type": "integer"
+                                          },
+                                          "timeoutSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "periodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "successThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "failureThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "terminationGracePeriodSeconds": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "readinessProbe": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "grpc": {
+                                            "properties": {
+                                              "port": {
+                                                "type": "integer"
+                                              },
+                                              "service": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "initialDelaySeconds": {
+                                            "type": "integer"
+                                          },
+                                          "timeoutSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "periodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "successThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "failureThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "terminationGracePeriodSeconds": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "startupProbe": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "grpc": {
+                                            "properties": {
+                                              "port": {
+                                                "type": "integer"
+                                              },
+                                              "service": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "initialDelaySeconds": {
+                                            "type": "integer"
+                                          },
+                                          "timeoutSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "periodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "successThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "failureThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "terminationGracePeriodSeconds": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "lifecycle": {
+                                        "properties": {
+                                          "postStart": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "exec": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "command": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "httpGet": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "path": {
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "properties": {
+                                                              "Type": {
+                                                                "type": "integer"
+                                                              },
+                                                              "IntVal": {
+                                                                "type": "integer"
+                                                              },
+                                                              "StrVal": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "host": {
+                                                            "type": "string"
+                                                          },
+                                                          "scheme": {
+                                                            "type": "string"
+                                                          },
+                                                          "httpHeaders": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "properties": {
+                                                                    "name": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "tcpSocket": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "port": {
+                                                            "properties": {
+                                                              "Type": {
+                                                                "type": "integer"
+                                                              },
+                                                              "IntVal": {
+                                                                "type": "integer"
+                                                              },
+                                                              "StrVal": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "host": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "preStop": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "exec": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "command": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "httpGet": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "path": {
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "properties": {
+                                                              "Type": {
+                                                                "type": "integer"
+                                                              },
+                                                              "IntVal": {
+                                                                "type": "integer"
+                                                              },
+                                                              "StrVal": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "host": {
+                                                            "type": "string"
+                                                          },
+                                                          "scheme": {
+                                                            "type": "string"
+                                                          },
+                                                          "httpHeaders": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "properties": {
+                                                                    "name": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "tcpSocket": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "port": {
+                                                            "properties": {
+                                                              "Type": {
+                                                                "type": "integer"
+                                                              },
+                                                              "IntVal": {
+                                                                "type": "integer"
+                                                              },
+                                                              "StrVal": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "host": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "terminationMessagePath": {
+                                        "type": "string"
+                                      },
+                                      "terminationMessagePolicy": {
+                                        "type": "string"
+                                      },
+                                      "imagePullPolicy": {
+                                        "type": "string"
+                                      },
+                                      "securityContext": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "capabilities": {
+                                                "properties": {
+                                                  "add": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "drop": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "privileged": {
+                                                "type": "boolean"
+                                              },
+                                              "seLinuxOptions": {
+                                                "properties": {
+                                                  "user": {
+                                                    "type": "string"
+                                                  },
+                                                  "role": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "level": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "windowsOptions": {
+                                                "properties": {
+                                                  "gmsaCredentialSpecName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "gmsaCredentialSpec": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "runAsUserName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "hostProcess": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "runAsUser": {
+                                                "type": "integer"
+                                              },
+                                              "runAsGroup": {
+                                                "type": "integer"
+                                              },
+                                              "runAsNonRoot": {
+                                                "type": "boolean"
+                                              },
+                                              "readOnlyRootFilesystem": {
+                                                "type": "boolean"
+                                              },
+                                              "allowPrivilegeEscalation": {
+                                                "type": "boolean"
+                                              },
+                                              "procMount": {
+                                                "type": "string"
+                                              },
+                                              "seccompProfile": {
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "localhostProfile": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "const": false
+                                          }
+                                        ]
+                                      },
+                                      "stdin": {
+                                        "type": "boolean"
+                                      },
+                                      "stdinOnce": {
+                                        "type": "boolean"
+                                      },
+                                      "tty": {
+                                        "type": "boolean"
+                                      },
+                                      "targetContainerName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            },
+                            "terminationGracePeriodSeconds": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "activeDeadlineSeconds": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "dnsPolicy": {
+                              "type": "string"
+                            },
+                            "nodeSelector": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "serviceAccount": {
+                              "type": "string"
+                            },
+                            "automountServiceAccountToken": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "nodeName": {
+                              "type": "string"
+                            },
+                            "hostNetwork": {
+                              "type": "boolean"
+                            },
+                            "hostPID": {
+                              "type": "boolean"
+                            },
+                            "hostIPC": {
+                              "type": "boolean"
+                            },
+                            "shareProcessNamespace": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "securityContext": {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "seLinuxOptions": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "user": {
+                                              "type": "string"
+                                            },
+                                            "role": {
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "type": "string"
+                                            },
+                                            "level": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "windowsOptions": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "gmsaCredentialSpecName": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "gmsaCredentialSpec": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "runAsUserName": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "hostProcess": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "runAsUser": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "runAsGroup": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "runAsNonRoot": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "supplementalGroups": {
+                                      "anyOf": [
+                                        {
+                                          "items": {
+                                            "type": "integer"
+                                          },
+                                          "type": "array"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "fsGroup": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "sysctls": {
+                                      "anyOf": [
+                                        {
+                                          "items": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "fsGroupChangePolicy": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "seccompProfile": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "type": {
+                                              "type": "string"
+                                            },
+                                            "localhostProfile": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "imagePullSecrets": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "hostname": {
+                              "type": "string"
+                            },
+                            "subdomain": {
+                              "type": "string"
+                            },
+                            "affinity": {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "nodeAffinity": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "properties": {
+                                                    "nodeSelectorTerms": {
+                                                      "anyOf": [
+                                                        {
+                                                          "items": {
+                                                            "properties": {
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchFields": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "items": {
+                                                    "properties": {
+                                                      "weight": {
+                                                        "type": "integer"
+                                                      },
+                                                      "preference": {
+                                                        "properties": {
+                                                          "matchExpressions": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "properties": {
+                                                                    "key": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "operator": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "values": {
+                                                                      "anyOf": [
+                                                                        {
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        {
+                                                                          "type": "null"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "matchFields": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "properties": {
+                                                                    "key": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "operator": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "values": {
+                                                                      "anyOf": [
+                                                                        {
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        {
+                                                                          "type": "null"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "podAffinity": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "items": {
+                                                    "properties": {
+                                                      "labelSelector": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "matchLabels": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "patternProperties": {
+                                                                      ".*": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "namespaces": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "topologyKey": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespaceSelector": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "matchLabels": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "patternProperties": {
+                                                                      ".*": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "items": {
+                                                    "properties": {
+                                                      "weight": {
+                                                        "type": "integer"
+                                                      },
+                                                      "podAffinityTerm": {
+                                                        "properties": {
+                                                          "labelSelector": {
+                                                            "anyOf": [
+                                                              {
+                                                                "properties": {
+                                                                  "matchLabels": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "patternProperties": {
+                                                                          ".*": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  "matchExpressions": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "items": {
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "anyOf": [
+                                                                                {
+                                                                                  "items": {
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "type": "array"
+                                                                                },
+                                                                                {
+                                                                                  "type": "null"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "namespaces": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "topologyKey": {
+                                                            "type": "string"
+                                                          },
+                                                          "namespaceSelector": {
+                                                            "anyOf": [
+                                                              {
+                                                                "properties": {
+                                                                  "matchLabels": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "patternProperties": {
+                                                                          ".*": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  "matchExpressions": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "items": {
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "anyOf": [
+                                                                                {
+                                                                                  "items": {
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "type": "array"
+                                                                                },
+                                                                                {
+                                                                                  "type": "null"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "podAntiAffinity": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "items": {
+                                                    "properties": {
+                                                      "labelSelector": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "matchLabels": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "patternProperties": {
+                                                                      ".*": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "namespaces": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "topologyKey": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespaceSelector": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "matchLabels": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "patternProperties": {
+                                                                      ".*": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "items": {
+                                                    "properties": {
+                                                      "weight": {
+                                                        "type": "integer"
+                                                      },
+                                                      "podAffinityTerm": {
+                                                        "properties": {
+                                                          "labelSelector": {
+                                                            "anyOf": [
+                                                              {
+                                                                "properties": {
+                                                                  "matchLabels": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "patternProperties": {
+                                                                          ".*": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  "matchExpressions": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "items": {
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "anyOf": [
+                                                                                {
+                                                                                  "items": {
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "type": "array"
+                                                                                },
+                                                                                {
+                                                                                  "type": "null"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "namespaces": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "topologyKey": {
+                                                            "type": "string"
+                                                          },
+                                                          "namespaceSelector": {
+                                                            "anyOf": [
+                                                              {
+                                                                "properties": {
+                                                                  "matchLabels": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "patternProperties": {
+                                                                          ".*": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  "matchExpressions": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "items": {
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "anyOf": [
+                                                                                {
+                                                                                  "items": {
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "type": "array"
+                                                                                },
+                                                                                {
+                                                                                  "type": "null"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "schedulerName": {
+                              "type": "string"
+                            },
+                            "tolerations": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      },
+                                      "effect": {
+                                        "type": "string"
+                                      },
+                                      "tolerationSeconds": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "hostAliases": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "ip": {
+                                        "type": "string"
+                                      },
+                                      "hostnames": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "priorityClassName": {
+                              "type": "string"
+                            },
+                            "priority": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "dnsConfig": {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "nameservers": {
+                                      "anyOf": [
+                                        {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "searches": {
+                                      "anyOf": [
+                                        {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "options": {
+                                      "anyOf": [
+                                        {
+                                          "items": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "readinessGates": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "conditionType": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "runtimeClassName": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "enableServiceLinks": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preemptionPolicy": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "overhead": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "topologySpreadConstraints": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "maxSkew": {
+                                        "type": "integer"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      },
+                                      "whenUnsatisfiable": {
+                                        "type": "string"
+                                      },
+                                      "labelSelector": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "matchLabels": {
+                                                "anyOf": [
+                                                  {
+                                                    "patternProperties": {
+                                                      ".*": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "matchExpressions": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "anyOf": [
+                                                            {
+                                                              "items": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "minDomains": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "nodeAffinityPolicy": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "nodeTaintsPolicy": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "matchLabelKeys": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "setHostnameAsFQDN": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "os": {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "hostUsers": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "strategy": {
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "rollingUpdate": {
+                          "anyOf": [
+                            {
+                              "properties": {
+                                "maxUnavailable": {
+                                  "anyOf": [
+                                    {
+                                      "properties": {
+                                        "Type": {
+                                          "type": "integer"
+                                        },
+                                        "IntVal": {
+                                          "type": "integer"
+                                        },
+                                        "StrVal": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "maxSurge": {
+                                  "anyOf": [
+                                    {
+                                      "properties": {
+                                        "Type": {
+                                          "type": "integer"
+                                        },
+                                        "IntVal": {
+                                          "type": "integer"
+                                        },
+                                        "StrVal": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "minReadySeconds": {
+                      "type": "integer"
+                    },
+                    "revisionHistoryLimit": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "paused": {
+                      "type": "boolean"
+                    },
+                    "progressDeadlineSeconds": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "status": {
+                  "properties": {
+                    "observedGeneration": {
+                      "type": "integer"
+                    },
+                    "replicas": {
+                      "type": "integer"
+                    },
+                    "updatedReplicas": {
+                      "type": "integer"
+                    },
+                    "readyReplicas": {
+                      "type": "integer"
+                    },
+                    "availableReplicas": {
+                      "type": "integer"
+                    },
+                    "unavailableReplicas": {
+                      "type": "integer"
+                    },
+                    "conditions": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "type": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "lastUpdateTime": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "lastTransitionTime": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "collisionCount": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "serviceOverrides": {
+          "anyOf": [
+            {
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "apiVersion": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "creationTimestamp": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deletionTimestamp": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "labels": {
+                      "anyOf": [
+                        {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "annotations": {
+                      "anyOf": [
+                        {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "ownerReferences": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              },
+                              "controller": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "blockOwnerDeletion": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "finalizers": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "managedFields": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "anyOf": [
+                                  {
+                                    "properties": {},
+                                    "type": "object"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "subresource": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "spec": {
+                  "properties": {
+                    "ports": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "type": "string"
+                              },
+                              "appProtocol": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "port": {
+                                "type": "integer"
+                              },
+                              "targetPort": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "integer"
+                                  },
+                                  "IntVal": {
+                                    "type": "integer"
+                                  },
+                                  "StrVal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "nodePort": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "selector": {
+                      "anyOf": [
+                        {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "clusterIP": {
+                      "type": "string"
+                    },
+                    "clusterIPs": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "externalIPs": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "sessionAffinity": {
+                      "type": "string"
+                    },
+                    "loadBalancerIP": {
+                      "type": "string"
+                    },
+                    "loadBalancerSourceRanges": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "externalName": {
+                      "type": "string"
+                    },
+                    "externalTrafficPolicy": {
+                      "type": "string"
+                    },
+                    "healthCheckNodePort": {
+                      "type": "integer"
+                    },
+                    "publishNotReadyAddresses": {
+                      "type": "boolean"
+                    },
+                    "sessionAffinityConfig": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "clientIP": {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "timeoutSeconds": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "ipFamilies": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "ipFamilyPolicy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "allocateLoadBalancerNodePorts": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "loadBalancerClass": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "internalTrafficPolicy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "status": {
+                  "properties": {
+                    "loadBalancer": {
+                      "properties": {
+                        "ingress": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "properties": {
+                                  "ip": {
+                                    "type": "string"
+                                  },
+                                  "hostname": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "anyOf": [
+                                      {
+                                        "items": {
+                                          "properties": {
+                                            "port": {
+                                              "type": "integer"
+                                            },
+                                            "protocol": {
+                                              "type": "string"
+                                            },
+                                            "error": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "conditions": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "type": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "observedGeneration": {
+                                "type": "integer"
+                              },
+                              "lastTransitionTime": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/codegen/test/chart-no-desc/values.schema.json
+++ b/codegen/test/chart-no-desc/values.schema.json
@@ -1,7 +1,7 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "properties": {
     "painter": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "image": {
           "properties": {

--- a/codegen/test/chart/values.schema.json
+++ b/codegen/test/chart/values.schema.json
@@ -1,0 +1,8816 @@
+{
+  "properties": {
+    "painter": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "image": {
+          "properties": {
+            "tag": {
+              "type": "string"
+            },
+            "repository": {
+              "type": "string"
+            },
+            "registry": {
+              "type": "string"
+            },
+            "pullPolicy": {
+              "type": "string"
+            },
+            "pullSecret": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "env": {
+          "anyOf": [
+            {
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {
+                    "type": "string"
+                  },
+                  "valueFrom": {
+                    "anyOf": [
+                      {
+                        "properties": {
+                          "fieldRef": {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "apiVersion": {
+                                    "type": "string"
+                                  },
+                                  "fieldPath": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "resourceFieldRef": {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "containerName": {
+                                    "type": "string"
+                                  },
+                                  "resource": {
+                                    "type": "string"
+                                  },
+                                  "divisor": {
+                                    "anyOf": [
+                                      {
+                                        "type": "string"
+                                      },
+                                      {
+                                        "type": "number"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "configMapKeyRef": {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "anyOf": [
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "secretKeyRef": {
+                            "anyOf": [
+                              {
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "optional": {
+                                    "anyOf": [
+                                      {
+                                        "type": "boolean"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "type": "object"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resources": {
+          "properties": {
+            "limits": {
+              "anyOf": [
+                {
+                  "patternProperties": {
+                    ".*": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "requests": {
+              "anyOf": [
+                {
+                  "patternProperties": {
+                    ".*": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "number"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        },
+        "securityContext": {
+          "anyOf": [
+            {
+              "properties": {
+                "capabilities": {
+                  "properties": {
+                    "add": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "drop": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "privileged": {
+                  "type": "boolean"
+                },
+                "seLinuxOptions": {
+                  "properties": {
+                    "user": {
+                      "type": "string"
+                    },
+                    "role": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "level": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "windowsOptions": {
+                  "properties": {
+                    "gmsaCredentialSpecName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "gmsaCredentialSpec": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "runAsUserName": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "hostProcess": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "runAsUser": {
+                  "type": "integer"
+                },
+                "runAsGroup": {
+                  "type": "integer"
+                },
+                "runAsNonRoot": {
+                  "type": "boolean"
+                },
+                "readOnlyRootFilesystem": {
+                  "type": "boolean"
+                },
+                "allowPrivilegeEscalation": {
+                  "type": "boolean"
+                },
+                "procMount": {
+                  "type": "string"
+                },
+                "seccompProfile": {
+                  "properties": {
+                    "type": {
+                      "type": "string"
+                    },
+                    "localhostProfile": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "boolean",
+              "const": false
+            }
+          ]
+        },
+        "sidecars": {
+          "anyOf": [
+            {
+              "patternProperties": {
+                ".*": {
+                  "properties": {
+                    "image": {
+                      "properties": {
+                        "tag": {
+                          "type": "string"
+                        },
+                        "repository": {
+                          "type": "string"
+                        },
+                        "registry": {
+                          "type": "string"
+                        },
+                        "pullPolicy": {
+                          "type": "string"
+                        },
+                        "pullSecret": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "env": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              },
+                              "valueFrom": {
+                                "anyOf": [
+                                  {
+                                    "properties": {
+                                      "fieldRef": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "apiVersion": {
+                                                "type": "string"
+                                              },
+                                              "fieldPath": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "resourceFieldRef": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "containerName": {
+                                                "type": "string"
+                                              },
+                                              "resource": {
+                                                "type": "string"
+                                              },
+                                              "divisor": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "configMapKeyRef": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "secretKeyRef": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "key": {
+                                                "type": "string"
+                                              },
+                                              "optional": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "resources": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "limits": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "requests": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "securityContext": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "capabilities": {
+                              "properties": {
+                                "add": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "drop": {
+                                  "anyOf": [
+                                    {
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "type": "array"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "privileged": {
+                              "type": "boolean"
+                            },
+                            "seLinuxOptions": {
+                              "properties": {
+                                "user": {
+                                  "type": "string"
+                                },
+                                "role": {
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "type": "string"
+                                },
+                                "level": {
+                                  "type": "string"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "windowsOptions": {
+                              "properties": {
+                                "gmsaCredentialSpecName": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "gmsaCredentialSpec": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "runAsUserName": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "hostProcess": {
+                                  "anyOf": [
+                                    {
+                                      "type": "boolean"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "runAsUser": {
+                              "type": "integer"
+                            },
+                            "runAsGroup": {
+                              "type": "integer"
+                            },
+                            "runAsNonRoot": {
+                              "type": "boolean"
+                            },
+                            "readOnlyRootFilesystem": {
+                              "type": "boolean"
+                            },
+                            "allowPrivilegeEscalation": {
+                              "type": "boolean"
+                            },
+                            "procMount": {
+                              "type": "string"
+                            },
+                            "seccompProfile": {
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "localhostProfile": {
+                                  "anyOf": [
+                                    {
+                                      "type": "string"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "boolean",
+                          "const": false
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "floatingUserId": {
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "type": "integer"
+        },
+        "serviceType": {
+          "type": "string"
+        },
+        "ports": {
+          "anyOf": [
+            {
+              "patternProperties": {
+                ".*": {
+                  "type": "integer"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "deploymentOverrides": {
+          "anyOf": [
+            {
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "apiVersion": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "creationTimestamp": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deletionTimestamp": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "labels": {
+                      "anyOf": [
+                        {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "annotations": {
+                      "anyOf": [
+                        {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "ownerReferences": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              },
+                              "controller": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "blockOwnerDeletion": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "finalizers": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "managedFields": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "anyOf": [
+                                  {
+                                    "properties": {},
+                                    "type": "object"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "subresource": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "spec": {
+                  "properties": {
+                    "replicas": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "selector": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "matchLabels": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "matchExpressions": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "values": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "template": {
+                      "properties": {
+                        "metadata": {
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "generateName": {
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "type": "string"
+                            },
+                            "selfLink": {
+                              "type": "string"
+                            },
+                            "uid": {
+                              "type": "string"
+                            },
+                            "resourceVersion": {
+                              "type": "string"
+                            },
+                            "generation": {
+                              "type": "integer"
+                            },
+                            "creationTimestamp": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "deletionTimestamp": {
+                              "anyOf": [
+                                {
+                                  "type": "string",
+                                  "format": "date-time"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "deletionGracePeriodSeconds": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "labels": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "annotations": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "ownerReferences": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "apiVersion": {
+                                        "type": "string"
+                                      },
+                                      "kind": {
+                                        "type": "string"
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "uid": {
+                                        "type": "string"
+                                      },
+                                      "controller": {
+                                        "anyOf": [
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "blockOwnerDeletion": {
+                                        "anyOf": [
+                                          {
+                                            "type": "boolean"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "finalizers": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "managedFields": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "manager": {
+                                        "type": "string"
+                                      },
+                                      "operation": {
+                                        "type": "string"
+                                      },
+                                      "apiVersion": {
+                                        "type": "string"
+                                      },
+                                      "time": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string",
+                                            "format": "date-time"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "fieldsType": {
+                                        "type": "string"
+                                      },
+                                      "fieldsV1": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {},
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "subresource": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        "spec": {
+                          "properties": {
+                            "volumes": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "hostPath": {
+                                        "properties": {
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "type": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "emptyDir": {
+                                        "properties": {
+                                          "medium": {
+                                            "type": "string"
+                                          },
+                                          "sizeLimit": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "number"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gcePersistentDisk": {
+                                        "properties": {
+                                          "pdName": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "partition": {
+                                            "type": "integer"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "awsElasticBlockStore": {
+                                        "properties": {
+                                          "volumeID": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "partition": {
+                                            "type": "integer"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "gitRepo": {
+                                        "properties": {
+                                          "repository": {
+                                            "type": "string"
+                                          },
+                                          "revision": {
+                                            "type": "string"
+                                          },
+                                          "directory": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "secret": {
+                                        "properties": {
+                                          "secretName": {
+                                            "type": "string"
+                                          },
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "mode": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "defaultMode": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "optional": {
+                                            "anyOf": [
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "nfs": {
+                                        "properties": {
+                                          "server": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "iscsi": {
+                                        "properties": {
+                                          "targetPortal": {
+                                            "type": "string"
+                                          },
+                                          "iqn": {
+                                            "type": "string"
+                                          },
+                                          "lun": {
+                                            "type": "integer"
+                                          },
+                                          "iscsiInterface": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "portals": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "chapAuthDiscovery": {
+                                            "type": "boolean"
+                                          },
+                                          "chapAuthSession": {
+                                            "type": "boolean"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "initiatorName": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "glusterfs": {
+                                        "properties": {
+                                          "endpoints": {
+                                            "type": "string"
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "persistentVolumeClaim": {
+                                        "properties": {
+                                          "claimName": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "rbd": {
+                                        "properties": {
+                                          "monitors": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "image": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "pool": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          },
+                                          "keyring": {
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "flexVolume": {
+                                        "properties": {
+                                          "driver": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "options": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "cinder": {
+                                        "properties": {
+                                          "volumeID": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "cephfs": {
+                                        "properties": {
+                                          "monitors": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "path": {
+                                            "type": "string"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          },
+                                          "secretFile": {
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "flocker": {
+                                        "properties": {
+                                          "datasetName": {
+                                            "type": "string"
+                                          },
+                                          "datasetUUID": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "downwardAPI": {
+                                        "properties": {
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "properties": {
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "fieldRef": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "apiVersion": {
+                                                              "type": "string"
+                                                            },
+                                                            "fieldPath": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "resourceFieldRef": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "containerName": {
+                                                              "type": "string"
+                                                            },
+                                                            "resource": {
+                                                              "type": "string"
+                                                            },
+                                                            "divisor": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "string"
+                                                                },
+                                                                {
+                                                                  "type": "number"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "mode": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "defaultMode": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "fc": {
+                                        "properties": {
+                                          "targetWWNs": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "lun": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "wwids": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "type": "string"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "azureFile": {
+                                        "properties": {
+                                          "secretName": {
+                                            "type": "string"
+                                          },
+                                          "shareName": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "configMap": {
+                                        "properties": {
+                                          "name": {
+                                            "type": "string"
+                                          },
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "properties": {
+                                                    "key": {
+                                                      "type": "string"
+                                                    },
+                                                    "path": {
+                                                      "type": "string"
+                                                    },
+                                                    "mode": {
+                                                      "anyOf": [
+                                                        {
+                                                          "type": "integer"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "defaultMode": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "optional": {
+                                            "anyOf": [
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "vsphereVolume": {
+                                        "properties": {
+                                          "volumePath": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "storagePolicyName": {
+                                            "type": "string"
+                                          },
+                                          "storagePolicyID": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "quobyte": {
+                                        "properties": {
+                                          "registry": {
+                                            "type": "string"
+                                          },
+                                          "volume": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "user": {
+                                            "type": "string"
+                                          },
+                                          "group": {
+                                            "type": "string"
+                                          },
+                                          "tenant": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "azureDisk": {
+                                        "properties": {
+                                          "diskName": {
+                                            "type": "string"
+                                          },
+                                          "diskURI": {
+                                            "type": "string"
+                                          },
+                                          "cachingMode": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "fsType": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "readOnly": {
+                                            "anyOf": [
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "kind": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "photonPersistentDisk": {
+                                        "properties": {
+                                          "pdID": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "projected": {
+                                        "properties": {
+                                          "sources": {
+                                            "anyOf": [
+                                              {
+                                                "items": {
+                                                  "properties": {
+                                                    "secret": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "items": {
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "path": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "mode": {
+                                                                        "anyOf": [
+                                                                          {
+                                                                            "type": "integer"
+                                                                          },
+                                                                          {
+                                                                            "type": "null"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            },
+                                                            "optional": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "downwardAPI": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "items": {
+                                                                    "properties": {
+                                                                      "path": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "fieldRef": {
+                                                                        "anyOf": [
+                                                                          {
+                                                                            "properties": {
+                                                                              "apiVersion": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "fieldPath": {
+                                                                                "type": "string"
+                                                                              }
+                                                                            },
+                                                                            "type": "object"
+                                                                          },
+                                                                          {
+                                                                            "type": "null"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      "resourceFieldRef": {
+                                                                        "anyOf": [
+                                                                          {
+                                                                            "properties": {
+                                                                              "containerName": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "resource": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "divisor": {
+                                                                                "anyOf": [
+                                                                                  {
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  {
+                                                                                    "type": "number"
+                                                                                  }
+                                                                                ]
+                                                                              }
+                                                                            },
+                                                                            "type": "object"
+                                                                          },
+                                                                          {
+                                                                            "type": "null"
+                                                                          }
+                                                                        ]
+                                                                      },
+                                                                      "mode": {
+                                                                        "anyOf": [
+                                                                          {
+                                                                            "type": "integer"
+                                                                          },
+                                                                          {
+                                                                            "type": "null"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "configMap": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "items": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "items": {
+                                                                    "properties": {
+                                                                      "key": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "path": {
+                                                                        "type": "string"
+                                                                      },
+                                                                      "mode": {
+                                                                        "anyOf": [
+                                                                          {
+                                                                            "type": "integer"
+                                                                          },
+                                                                          {
+                                                                            "type": "null"
+                                                                          }
+                                                                        ]
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  "type": "array"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            },
+                                                            "optional": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "boolean"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    },
+                                                    "serviceAccountToken": {
+                                                      "anyOf": [
+                                                        {
+                                                          "properties": {
+                                                            "audience": {
+                                                              "type": "string"
+                                                            },
+                                                            "expirationSeconds": {
+                                                              "anyOf": [
+                                                                {
+                                                                  "type": "integer"
+                                                                },
+                                                                {
+                                                                  "type": "null"
+                                                                }
+                                                              ]
+                                                            },
+                                                            "path": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "type": "array"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "defaultMode": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "portworxVolume": {
+                                        "properties": {
+                                          "volumeID": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "scaleIO": {
+                                        "properties": {
+                                          "gateway": {
+                                            "type": "string"
+                                          },
+                                          "system": {
+                                            "type": "string"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "sslEnabled": {
+                                            "type": "boolean"
+                                          },
+                                          "protectionDomain": {
+                                            "type": "string"
+                                          },
+                                          "storagePool": {
+                                            "type": "string"
+                                          },
+                                          "storageMode": {
+                                            "type": "string"
+                                          },
+                                          "volumeName": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "storageos": {
+                                        "properties": {
+                                          "volumeName": {
+                                            "type": "string"
+                                          },
+                                          "volumeNamespace": {
+                                            "type": "string"
+                                          },
+                                          "fsType": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "type": "boolean"
+                                          },
+                                          "secretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "csi": {
+                                        "properties": {
+                                          "driver": {
+                                            "type": "string"
+                                          },
+                                          "readOnly": {
+                                            "anyOf": [
+                                              {
+                                                "type": "boolean"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "fsType": {
+                                            "anyOf": [
+                                              {
+                                                "type": "string"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "volumeAttributes": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "nodePublishSecretRef": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "name": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "ephemeral": {
+                                        "properties": {
+                                          "volumeClaimTemplate": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "metadata": {
+                                                    "properties": {
+                                                      "name": {
+                                                        "type": "string"
+                                                      },
+                                                      "generateName": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespace": {
+                                                        "type": "string"
+                                                      },
+                                                      "selfLink": {
+                                                        "type": "string"
+                                                      },
+                                                      "uid": {
+                                                        "type": "string"
+                                                      },
+                                                      "resourceVersion": {
+                                                        "type": "string"
+                                                      },
+                                                      "generation": {
+                                                        "type": "integer"
+                                                      },
+                                                      "creationTimestamp": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string",
+                                                            "format": "date-time"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "deletionTimestamp": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string",
+                                                            "format": "date-time"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "deletionGracePeriodSeconds": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "integer"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "labels": {
+                                                        "anyOf": [
+                                                          {
+                                                            "patternProperties": {
+                                                              ".*": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "annotations": {
+                                                        "anyOf": [
+                                                          {
+                                                            "patternProperties": {
+                                                              ".*": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "ownerReferences": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "properties": {
+                                                                "apiVersion": {
+                                                                  "type": "string"
+                                                                },
+                                                                "kind": {
+                                                                  "type": "string"
+                                                                },
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "uid": {
+                                                                  "type": "string"
+                                                                },
+                                                                "controller": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "blockOwnerDeletion": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "finalizers": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "managedFields": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "properties": {
+                                                                "manager": {
+                                                                  "type": "string"
+                                                                },
+                                                                "operation": {
+                                                                  "type": "string"
+                                                                },
+                                                                "apiVersion": {
+                                                                  "type": "string"
+                                                                },
+                                                                "time": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string",
+                                                                      "format": "date-time"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "fieldsType": {
+                                                                  "type": "string"
+                                                                },
+                                                                "fieldsV1": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "properties": {},
+                                                                      "type": "object"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                },
+                                                                "subresource": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "spec": {
+                                                    "properties": {
+                                                      "accessModes": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "selector": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "matchLabels": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "patternProperties": {
+                                                                      ".*": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "resources": {
+                                                        "properties": {
+                                                          "limits": {
+                                                            "anyOf": [
+                                                              {
+                                                                "patternProperties": {
+                                                                  ".*": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "type": "string"
+                                                                      },
+                                                                      {
+                                                                        "type": "number"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "requests": {
+                                                            "anyOf": [
+                                                              {
+                                                                "patternProperties": {
+                                                                  ".*": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "type": "string"
+                                                                      },
+                                                                      {
+                                                                        "type": "number"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      "volumeName": {
+                                                        "type": "string"
+                                                      },
+                                                      "storageClassName": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "volumeMode": {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataSource": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "apiGroup": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "dataSourceRef": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "apiGroup": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "type": "string"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "kind": {
+                                                                "type": "string"
+                                                              },
+                                                              "name": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "initContainers": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "image": {
+                                        "type": "string"
+                                      },
+                                      "command": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "args": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "workingDir": {
+                                        "type": "string"
+                                      },
+                                      "ports": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "hostPort": {
+                                                  "type": "integer"
+                                                },
+                                                "containerPort": {
+                                                  "type": "integer"
+                                                },
+                                                "protocol": {
+                                                  "type": "string"
+                                                },
+                                                "hostIP": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "envFrom": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "prefix": {
+                                                  "type": "string"
+                                                },
+                                                "configMapRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "secretRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "env": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                },
+                                                "valueFrom": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "fieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "apiVersion": {
+                                                                  "type": "string"
+                                                                },
+                                                                "fieldPath": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "resourceFieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "containerName": {
+                                                                  "type": "string"
+                                                                },
+                                                                "resource": {
+                                                                  "type": "string"
+                                                                },
+                                                                "divisor": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "configMapKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "secretKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "requests": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "volumeMounts": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "readOnly": {
+                                                  "type": "boolean"
+                                                },
+                                                "mountPath": {
+                                                  "type": "string"
+                                                },
+                                                "subPath": {
+                                                  "type": "string"
+                                                },
+                                                "mountPropagation": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "subPathExpr": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "volumeDevices": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "devicePath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "livenessProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "readinessProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "startupProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "lifecycle": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "postStart": {
+                                                "anyOf": [
+                                                  {
+                                                    "properties": {
+                                                      "exec": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "command": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "httpGet": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "path": {
+                                                                "type": "string"
+                                                              },
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              },
+                                                              "scheme": {
+                                                                "type": "string"
+                                                              },
+                                                              "httpHeaders": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "name": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "tcpSocket": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "preStop": {
+                                                "anyOf": [
+                                                  {
+                                                    "properties": {
+                                                      "exec": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "command": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "httpGet": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "path": {
+                                                                "type": "string"
+                                                              },
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              },
+                                                              "scheme": {
+                                                                "type": "string"
+                                                              },
+                                                              "httpHeaders": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "name": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "tcpSocket": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "terminationMessagePath": {
+                                        "type": "string"
+                                      },
+                                      "terminationMessagePolicy": {
+                                        "type": "string"
+                                      },
+                                      "imagePullPolicy": {
+                                        "type": "string"
+                                      },
+                                      "securityContext": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "capabilities": {
+                                                "properties": {
+                                                  "add": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "drop": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "privileged": {
+                                                "type": "boolean"
+                                              },
+                                              "seLinuxOptions": {
+                                                "properties": {
+                                                  "user": {
+                                                    "type": "string"
+                                                  },
+                                                  "role": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "level": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "windowsOptions": {
+                                                "properties": {
+                                                  "gmsaCredentialSpecName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "gmsaCredentialSpec": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "runAsUserName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "hostProcess": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "runAsUser": {
+                                                "type": "integer"
+                                              },
+                                              "runAsGroup": {
+                                                "type": "integer"
+                                              },
+                                              "runAsNonRoot": {
+                                                "type": "boolean"
+                                              },
+                                              "readOnlyRootFilesystem": {
+                                                "type": "boolean"
+                                              },
+                                              "allowPrivilegeEscalation": {
+                                                "type": "boolean"
+                                              },
+                                              "procMount": {
+                                                "type": "string"
+                                              },
+                                              "seccompProfile": {
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "localhostProfile": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "const": false
+                                          }
+                                        ]
+                                      },
+                                      "stdin": {
+                                        "type": "boolean"
+                                      },
+                                      "stdinOnce": {
+                                        "type": "boolean"
+                                      },
+                                      "tty": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "containers": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "image": {
+                                        "type": "string"
+                                      },
+                                      "command": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "args": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "workingDir": {
+                                        "type": "string"
+                                      },
+                                      "ports": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "hostPort": {
+                                                  "type": "integer"
+                                                },
+                                                "containerPort": {
+                                                  "type": "integer"
+                                                },
+                                                "protocol": {
+                                                  "type": "string"
+                                                },
+                                                "hostIP": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "envFrom": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "prefix": {
+                                                  "type": "string"
+                                                },
+                                                "configMapRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "secretRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "env": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                },
+                                                "valueFrom": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "fieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "apiVersion": {
+                                                                  "type": "string"
+                                                                },
+                                                                "fieldPath": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "resourceFieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "containerName": {
+                                                                  "type": "string"
+                                                                },
+                                                                "resource": {
+                                                                  "type": "string"
+                                                                },
+                                                                "divisor": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "configMapKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "secretKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "requests": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "volumeMounts": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "readOnly": {
+                                                  "type": "boolean"
+                                                },
+                                                "mountPath": {
+                                                  "type": "string"
+                                                },
+                                                "subPath": {
+                                                  "type": "string"
+                                                },
+                                                "mountPropagation": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "subPathExpr": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "volumeDevices": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "devicePath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "livenessProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "readinessProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "startupProbe": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "exec": {
+                                                "properties": {
+                                                  "command": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "httpGet": {
+                                                "properties": {
+                                                  "path": {
+                                                    "type": "string"
+                                                  },
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  },
+                                                  "scheme": {
+                                                    "type": "string"
+                                                  },
+                                                  "httpHeaders": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "properties": {
+                                                            "name": {
+                                                              "type": "string"
+                                                            },
+                                                            "value": {
+                                                              "type": "string"
+                                                            }
+                                                          },
+                                                          "type": "object"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "tcpSocket": {
+                                                "properties": {
+                                                  "port": {
+                                                    "properties": {
+                                                      "Type": {
+                                                        "type": "integer"
+                                                      },
+                                                      "IntVal": {
+                                                        "type": "integer"
+                                                      },
+                                                      "StrVal": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "host": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "grpc": {
+                                                "properties": {
+                                                  "port": {
+                                                    "type": "integer"
+                                                  },
+                                                  "service": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "initialDelaySeconds": {
+                                                "type": "integer"
+                                              },
+                                              "timeoutSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "periodSeconds": {
+                                                "type": "integer"
+                                              },
+                                              "successThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "failureThreshold": {
+                                                "type": "integer"
+                                              },
+                                              "terminationGracePeriodSeconds": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "integer"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "lifecycle": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "postStart": {
+                                                "anyOf": [
+                                                  {
+                                                    "properties": {
+                                                      "exec": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "command": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "httpGet": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "path": {
+                                                                "type": "string"
+                                                              },
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              },
+                                                              "scheme": {
+                                                                "type": "string"
+                                                              },
+                                                              "httpHeaders": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "name": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "tcpSocket": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "preStop": {
+                                                "anyOf": [
+                                                  {
+                                                    "properties": {
+                                                      "exec": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "command": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "httpGet": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "path": {
+                                                                "type": "string"
+                                                              },
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              },
+                                                              "scheme": {
+                                                                "type": "string"
+                                                              },
+                                                              "httpHeaders": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "name": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "value": {
+                                                                          "type": "string"
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "tcpSocket": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "port": {
+                                                                "properties": {
+                                                                  "Type": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "IntVal": {
+                                                                    "type": "integer"
+                                                                  },
+                                                                  "StrVal": {
+                                                                    "type": "string"
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              "host": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "terminationMessagePath": {
+                                        "type": "string"
+                                      },
+                                      "terminationMessagePolicy": {
+                                        "type": "string"
+                                      },
+                                      "imagePullPolicy": {
+                                        "type": "string"
+                                      },
+                                      "securityContext": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "capabilities": {
+                                                "properties": {
+                                                  "add": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "drop": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "privileged": {
+                                                "type": "boolean"
+                                              },
+                                              "seLinuxOptions": {
+                                                "properties": {
+                                                  "user": {
+                                                    "type": "string"
+                                                  },
+                                                  "role": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "level": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "windowsOptions": {
+                                                "properties": {
+                                                  "gmsaCredentialSpecName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "gmsaCredentialSpec": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "runAsUserName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "hostProcess": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "runAsUser": {
+                                                "type": "integer"
+                                              },
+                                              "runAsGroup": {
+                                                "type": "integer"
+                                              },
+                                              "runAsNonRoot": {
+                                                "type": "boolean"
+                                              },
+                                              "readOnlyRootFilesystem": {
+                                                "type": "boolean"
+                                              },
+                                              "allowPrivilegeEscalation": {
+                                                "type": "boolean"
+                                              },
+                                              "procMount": {
+                                                "type": "string"
+                                              },
+                                              "seccompProfile": {
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "localhostProfile": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "const": false
+                                          }
+                                        ]
+                                      },
+                                      "stdin": {
+                                        "type": "boolean"
+                                      },
+                                      "stdinOnce": {
+                                        "type": "boolean"
+                                      },
+                                      "tty": {
+                                        "type": "boolean"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "ephemeralContainers": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "image": {
+                                        "type": "string"
+                                      },
+                                      "command": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "args": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "workingDir": {
+                                        "type": "string"
+                                      },
+                                      "ports": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "hostPort": {
+                                                  "type": "integer"
+                                                },
+                                                "containerPort": {
+                                                  "type": "integer"
+                                                },
+                                                "protocol": {
+                                                  "type": "string"
+                                                },
+                                                "hostIP": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "envFrom": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "prefix": {
+                                                  "type": "string"
+                                                },
+                                                "configMapRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "secretRef": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "optional": {
+                                                          "anyOf": [
+                                                            {
+                                                              "type": "boolean"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "env": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "value": {
+                                                  "type": "string"
+                                                },
+                                                "valueFrom": {
+                                                  "anyOf": [
+                                                    {
+                                                      "properties": {
+                                                        "fieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "apiVersion": {
+                                                                  "type": "string"
+                                                                },
+                                                                "fieldPath": {
+                                                                  "type": "string"
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "resourceFieldRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "containerName": {
+                                                                  "type": "string"
+                                                                },
+                                                                "resource": {
+                                                                  "type": "string"
+                                                                },
+                                                                "divisor": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "string"
+                                                                    },
+                                                                    {
+                                                                      "type": "number"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "configMapKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        },
+                                                        "secretKeyRef": {
+                                                          "anyOf": [
+                                                            {
+                                                              "properties": {
+                                                                "name": {
+                                                                  "type": "string"
+                                                                },
+                                                                "key": {
+                                                                  "type": "string"
+                                                                },
+                                                                "optional": {
+                                                                  "anyOf": [
+                                                                    {
+                                                                      "type": "boolean"
+                                                                    },
+                                                                    {
+                                                                      "type": "null"
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              },
+                                                              "type": "object"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "resources": {
+                                        "properties": {
+                                          "limits": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "requests": {
+                                            "anyOf": [
+                                              {
+                                                "patternProperties": {
+                                                  ".*": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "volumeMounts": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "readOnly": {
+                                                  "type": "boolean"
+                                                },
+                                                "mountPath": {
+                                                  "type": "string"
+                                                },
+                                                "subPath": {
+                                                  "type": "string"
+                                                },
+                                                "mountPropagation": {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "null"
+                                                    }
+                                                  ]
+                                                },
+                                                "subPathExpr": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "volumeDevices": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "properties": {
+                                                "name": {
+                                                  "type": "string"
+                                                },
+                                                "devicePath": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "type": "object"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "livenessProbe": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "grpc": {
+                                            "properties": {
+                                              "port": {
+                                                "type": "integer"
+                                              },
+                                              "service": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "initialDelaySeconds": {
+                                            "type": "integer"
+                                          },
+                                          "timeoutSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "periodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "successThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "failureThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "terminationGracePeriodSeconds": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "readinessProbe": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "grpc": {
+                                            "properties": {
+                                              "port": {
+                                                "type": "integer"
+                                              },
+                                              "service": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "initialDelaySeconds": {
+                                            "type": "integer"
+                                          },
+                                          "timeoutSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "periodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "successThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "failureThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "terminationGracePeriodSeconds": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "startupProbe": {
+                                        "properties": {
+                                          "exec": {
+                                            "properties": {
+                                              "command": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "httpGet": {
+                                            "properties": {
+                                              "path": {
+                                                "type": "string"
+                                              },
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              },
+                                              "scheme": {
+                                                "type": "string"
+                                              },
+                                              "httpHeaders": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "properties": {
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "value": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "tcpSocket": {
+                                            "properties": {
+                                              "port": {
+                                                "properties": {
+                                                  "Type": {
+                                                    "type": "integer"
+                                                  },
+                                                  "IntVal": {
+                                                    "type": "integer"
+                                                  },
+                                                  "StrVal": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "host": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "grpc": {
+                                            "properties": {
+                                              "port": {
+                                                "type": "integer"
+                                              },
+                                              "service": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "initialDelaySeconds": {
+                                            "type": "integer"
+                                          },
+                                          "timeoutSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "periodSeconds": {
+                                            "type": "integer"
+                                          },
+                                          "successThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "failureThreshold": {
+                                            "type": "integer"
+                                          },
+                                          "terminationGracePeriodSeconds": {
+                                            "anyOf": [
+                                              {
+                                                "type": "integer"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "lifecycle": {
+                                        "properties": {
+                                          "postStart": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "exec": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "command": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "httpGet": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "path": {
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "properties": {
+                                                              "Type": {
+                                                                "type": "integer"
+                                                              },
+                                                              "IntVal": {
+                                                                "type": "integer"
+                                                              },
+                                                              "StrVal": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "host": {
+                                                            "type": "string"
+                                                          },
+                                                          "scheme": {
+                                                            "type": "string"
+                                                          },
+                                                          "httpHeaders": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "properties": {
+                                                                    "name": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "tcpSocket": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "port": {
+                                                            "properties": {
+                                                              "Type": {
+                                                                "type": "integer"
+                                                              },
+                                                              "IntVal": {
+                                                                "type": "integer"
+                                                              },
+                                                              "StrVal": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "host": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          },
+                                          "preStop": {
+                                            "anyOf": [
+                                              {
+                                                "properties": {
+                                                  "exec": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "command": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "httpGet": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "path": {
+                                                            "type": "string"
+                                                          },
+                                                          "port": {
+                                                            "properties": {
+                                                              "Type": {
+                                                                "type": "integer"
+                                                              },
+                                                              "IntVal": {
+                                                                "type": "integer"
+                                                              },
+                                                              "StrVal": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "host": {
+                                                            "type": "string"
+                                                          },
+                                                          "scheme": {
+                                                            "type": "string"
+                                                          },
+                                                          "httpHeaders": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "properties": {
+                                                                    "name": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "value": {
+                                                                      "type": "string"
+                                                                    }
+                                                                  },
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "tcpSocket": {
+                                                    "anyOf": [
+                                                      {
+                                                        "properties": {
+                                                          "port": {
+                                                            "properties": {
+                                                              "Type": {
+                                                                "type": "integer"
+                                                              },
+                                                              "IntVal": {
+                                                                "type": "integer"
+                                                              },
+                                                              "StrVal": {
+                                                                "type": "string"
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "host": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              {
+                                                "type": "null"
+                                              }
+                                            ]
+                                          }
+                                        },
+                                        "type": "object"
+                                      },
+                                      "terminationMessagePath": {
+                                        "type": "string"
+                                      },
+                                      "terminationMessagePolicy": {
+                                        "type": "string"
+                                      },
+                                      "imagePullPolicy": {
+                                        "type": "string"
+                                      },
+                                      "securityContext": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "capabilities": {
+                                                "properties": {
+                                                  "add": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "drop": {
+                                                    "anyOf": [
+                                                      {
+                                                        "items": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "array"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "privileged": {
+                                                "type": "boolean"
+                                              },
+                                              "seLinuxOptions": {
+                                                "properties": {
+                                                  "user": {
+                                                    "type": "string"
+                                                  },
+                                                  "role": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "level": {
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "windowsOptions": {
+                                                "properties": {
+                                                  "gmsaCredentialSpecName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "gmsaCredentialSpec": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "runAsUserName": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  },
+                                                  "hostProcess": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              },
+                                              "runAsUser": {
+                                                "type": "integer"
+                                              },
+                                              "runAsGroup": {
+                                                "type": "integer"
+                                              },
+                                              "runAsNonRoot": {
+                                                "type": "boolean"
+                                              },
+                                              "readOnlyRootFilesystem": {
+                                                "type": "boolean"
+                                              },
+                                              "allowPrivilegeEscalation": {
+                                                "type": "boolean"
+                                              },
+                                              "procMount": {
+                                                "type": "string"
+                                              },
+                                              "seccompProfile": {
+                                                "properties": {
+                                                  "type": {
+                                                    "type": "string"
+                                                  },
+                                                  "localhostProfile": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "null"
+                                                      }
+                                                    ]
+                                                  }
+                                                },
+                                                "type": "object"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "boolean",
+                                            "const": false
+                                          }
+                                        ]
+                                      },
+                                      "stdin": {
+                                        "type": "boolean"
+                                      },
+                                      "stdinOnce": {
+                                        "type": "boolean"
+                                      },
+                                      "tty": {
+                                        "type": "boolean"
+                                      },
+                                      "targetContainerName": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "restartPolicy": {
+                              "type": "string"
+                            },
+                            "terminationGracePeriodSeconds": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "activeDeadlineSeconds": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "dnsPolicy": {
+                              "type": "string"
+                            },
+                            "nodeSelector": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "serviceAccountName": {
+                              "type": "string"
+                            },
+                            "serviceAccount": {
+                              "type": "string"
+                            },
+                            "automountServiceAccountToken": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "nodeName": {
+                              "type": "string"
+                            },
+                            "hostNetwork": {
+                              "type": "boolean"
+                            },
+                            "hostPID": {
+                              "type": "boolean"
+                            },
+                            "hostIPC": {
+                              "type": "boolean"
+                            },
+                            "shareProcessNamespace": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "securityContext": {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "seLinuxOptions": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "user": {
+                                              "type": "string"
+                                            },
+                                            "role": {
+                                              "type": "string"
+                                            },
+                                            "type": {
+                                              "type": "string"
+                                            },
+                                            "level": {
+                                              "type": "string"
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "windowsOptions": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "gmsaCredentialSpecName": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "gmsaCredentialSpec": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "runAsUserName": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "hostProcess": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "runAsUser": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "runAsGroup": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "runAsNonRoot": {
+                                      "anyOf": [
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "supplementalGroups": {
+                                      "anyOf": [
+                                        {
+                                          "items": {
+                                            "type": "integer"
+                                          },
+                                          "type": "array"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "fsGroup": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "sysctls": {
+                                      "anyOf": [
+                                        {
+                                          "items": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "fsGroupChangePolicy": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "seccompProfile": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "type": {
+                                              "type": "string"
+                                            },
+                                            "localhostProfile": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "imagePullSecrets": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "hostname": {
+                              "type": "string"
+                            },
+                            "subdomain": {
+                              "type": "string"
+                            },
+                            "affinity": {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "nodeAffinity": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "properties": {
+                                                    "nodeSelectorTerms": {
+                                                      "anyOf": [
+                                                        {
+                                                          "items": {
+                                                            "properties": {
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchFields": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          "type": "array"
+                                                        },
+                                                        {
+                                                          "type": "null"
+                                                        }
+                                                      ]
+                                                    }
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "items": {
+                                                    "properties": {
+                                                      "weight": {
+                                                        "type": "integer"
+                                                      },
+                                                      "preference": {
+                                                        "properties": {
+                                                          "matchExpressions": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "properties": {
+                                                                    "key": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "operator": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "values": {
+                                                                      "anyOf": [
+                                                                        {
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        {
+                                                                          "type": "null"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "matchFields": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "properties": {
+                                                                    "key": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "operator": {
+                                                                      "type": "string"
+                                                                    },
+                                                                    "values": {
+                                                                      "anyOf": [
+                                                                        {
+                                                                          "items": {
+                                                                            "type": "string"
+                                                                          },
+                                                                          "type": "array"
+                                                                        },
+                                                                        {
+                                                                          "type": "null"
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  },
+                                                                  "type": "object"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "podAffinity": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "items": {
+                                                    "properties": {
+                                                      "labelSelector": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "matchLabels": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "patternProperties": {
+                                                                      ".*": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "namespaces": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "topologyKey": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespaceSelector": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "matchLabels": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "patternProperties": {
+                                                                      ".*": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "items": {
+                                                    "properties": {
+                                                      "weight": {
+                                                        "type": "integer"
+                                                      },
+                                                      "podAffinityTerm": {
+                                                        "properties": {
+                                                          "labelSelector": {
+                                                            "anyOf": [
+                                                              {
+                                                                "properties": {
+                                                                  "matchLabels": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "patternProperties": {
+                                                                          ".*": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  "matchExpressions": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "items": {
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "anyOf": [
+                                                                                {
+                                                                                  "items": {
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "type": "array"
+                                                                                },
+                                                                                {
+                                                                                  "type": "null"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "namespaces": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "topologyKey": {
+                                                            "type": "string"
+                                                          },
+                                                          "namespaceSelector": {
+                                                            "anyOf": [
+                                                              {
+                                                                "properties": {
+                                                                  "matchLabels": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "patternProperties": {
+                                                                          ".*": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  "matchExpressions": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "items": {
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "anyOf": [
+                                                                                {
+                                                                                  "items": {
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "type": "array"
+                                                                                },
+                                                                                {
+                                                                                  "type": "null"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "podAntiAffinity": {
+                                      "anyOf": [
+                                        {
+                                          "properties": {
+                                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "items": {
+                                                    "properties": {
+                                                      "labelSelector": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "matchLabels": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "patternProperties": {
+                                                                      ".*": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "namespaces": {
+                                                        "anyOf": [
+                                                          {
+                                                            "items": {
+                                                              "type": "string"
+                                                            },
+                                                            "type": "array"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      },
+                                                      "topologyKey": {
+                                                        "type": "string"
+                                                      },
+                                                      "namespaceSelector": {
+                                                        "anyOf": [
+                                                          {
+                                                            "properties": {
+                                                              "matchLabels": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "patternProperties": {
+                                                                      ".*": {
+                                                                        "type": "string"
+                                                                      }
+                                                                    },
+                                                                    "type": "object"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              },
+                                                              "matchExpressions": {
+                                                                "anyOf": [
+                                                                  {
+                                                                    "items": {
+                                                                      "properties": {
+                                                                        "key": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "operator": {
+                                                                          "type": "string"
+                                                                        },
+                                                                        "values": {
+                                                                          "anyOf": [
+                                                                            {
+                                                                              "items": {
+                                                                                "type": "string"
+                                                                              },
+                                                                              "type": "array"
+                                                                            },
+                                                                            {
+                                                                              "type": "null"
+                                                                            }
+                                                                          ]
+                                                                        }
+                                                                      },
+                                                                      "type": "object"
+                                                                    },
+                                                                    "type": "array"
+                                                                  },
+                                                                  {
+                                                                    "type": "null"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
+                                                            "type": "object"
+                                                          },
+                                                          {
+                                                            "type": "null"
+                                                          }
+                                                        ]
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            },
+                                            "preferredDuringSchedulingIgnoredDuringExecution": {
+                                              "anyOf": [
+                                                {
+                                                  "items": {
+                                                    "properties": {
+                                                      "weight": {
+                                                        "type": "integer"
+                                                      },
+                                                      "podAffinityTerm": {
+                                                        "properties": {
+                                                          "labelSelector": {
+                                                            "anyOf": [
+                                                              {
+                                                                "properties": {
+                                                                  "matchLabels": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "patternProperties": {
+                                                                          ".*": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  "matchExpressions": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "items": {
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "anyOf": [
+                                                                                {
+                                                                                  "items": {
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "type": "array"
+                                                                                },
+                                                                                {
+                                                                                  "type": "null"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "namespaces": {
+                                                            "anyOf": [
+                                                              {
+                                                                "items": {
+                                                                  "type": "string"
+                                                                },
+                                                                "type": "array"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          },
+                                                          "topologyKey": {
+                                                            "type": "string"
+                                                          },
+                                                          "namespaceSelector": {
+                                                            "anyOf": [
+                                                              {
+                                                                "properties": {
+                                                                  "matchLabels": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "patternProperties": {
+                                                                          ".*": {
+                                                                            "type": "string"
+                                                                          }
+                                                                        },
+                                                                        "type": "object"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  },
+                                                                  "matchExpressions": {
+                                                                    "anyOf": [
+                                                                      {
+                                                                        "items": {
+                                                                          "properties": {
+                                                                            "key": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "operator": {
+                                                                              "type": "string"
+                                                                            },
+                                                                            "values": {
+                                                                              "anyOf": [
+                                                                                {
+                                                                                  "items": {
+                                                                                    "type": "string"
+                                                                                  },
+                                                                                  "type": "array"
+                                                                                },
+                                                                                {
+                                                                                  "type": "null"
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          },
+                                                                          "type": "object"
+                                                                        },
+                                                                        "type": "array"
+                                                                      },
+                                                                      {
+                                                                        "type": "null"
+                                                                      }
+                                                                    ]
+                                                                  }
+                                                                },
+                                                                "type": "object"
+                                                              },
+                                                              {
+                                                                "type": "null"
+                                                              }
+                                                            ]
+                                                          }
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  "type": "array"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "schedulerName": {
+                              "type": "string"
+                            },
+                            "tolerations": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "key": {
+                                        "type": "string"
+                                      },
+                                      "operator": {
+                                        "type": "string"
+                                      },
+                                      "value": {
+                                        "type": "string"
+                                      },
+                                      "effect": {
+                                        "type": "string"
+                                      },
+                                      "tolerationSeconds": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "hostAliases": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "ip": {
+                                        "type": "string"
+                                      },
+                                      "hostnames": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "priorityClassName": {
+                              "type": "string"
+                            },
+                            "priority": {
+                              "anyOf": [
+                                {
+                                  "type": "integer"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "dnsConfig": {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "nameservers": {
+                                      "anyOf": [
+                                        {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "searches": {
+                                      "anyOf": [
+                                        {
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "type": "array"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    },
+                                    "options": {
+                                      "anyOf": [
+                                        {
+                                          "items": {
+                                            "properties": {
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "value": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          "type": "array"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "readinessGates": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "conditionType": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "runtimeClassName": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "enableServiceLinks": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "preemptionPolicy": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "overhead": {
+                              "anyOf": [
+                                {
+                                  "patternProperties": {
+                                    ".*": {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "topologySpreadConstraints": {
+                              "anyOf": [
+                                {
+                                  "items": {
+                                    "properties": {
+                                      "maxSkew": {
+                                        "type": "integer"
+                                      },
+                                      "topologyKey": {
+                                        "type": "string"
+                                      },
+                                      "whenUnsatisfiable": {
+                                        "type": "string"
+                                      },
+                                      "labelSelector": {
+                                        "anyOf": [
+                                          {
+                                            "properties": {
+                                              "matchLabels": {
+                                                "anyOf": [
+                                                  {
+                                                    "patternProperties": {
+                                                      ".*": {
+                                                        "type": "string"
+                                                      }
+                                                    },
+                                                    "type": "object"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              },
+                                              "matchExpressions": {
+                                                "anyOf": [
+                                                  {
+                                                    "items": {
+                                                      "properties": {
+                                                        "key": {
+                                                          "type": "string"
+                                                        },
+                                                        "operator": {
+                                                          "type": "string"
+                                                        },
+                                                        "values": {
+                                                          "anyOf": [
+                                                            {
+                                                              "items": {
+                                                                "type": "string"
+                                                              },
+                                                              "type": "array"
+                                                            },
+                                                            {
+                                                              "type": "null"
+                                                            }
+                                                          ]
+                                                        }
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "type": "array"
+                                                  },
+                                                  {
+                                                    "type": "null"
+                                                  }
+                                                ]
+                                              }
+                                            },
+                                            "type": "object"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "minDomains": {
+                                        "anyOf": [
+                                          {
+                                            "type": "integer"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "nodeAffinityPolicy": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "nodeTaintsPolicy": {
+                                        "anyOf": [
+                                          {
+                                            "type": "string"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      },
+                                      "matchLabelKeys": {
+                                        "anyOf": [
+                                          {
+                                            "items": {
+                                              "type": "string"
+                                            },
+                                            "type": "array"
+                                          },
+                                          {
+                                            "type": "null"
+                                          }
+                                        ]
+                                      }
+                                    },
+                                    "type": "object"
+                                  },
+                                  "type": "array"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "setHostnameAsFQDN": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "os": {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "name": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            },
+                            "hostUsers": {
+                              "anyOf": [
+                                {
+                                  "type": "boolean"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "strategy": {
+                      "properties": {
+                        "type": {
+                          "type": "string"
+                        },
+                        "rollingUpdate": {
+                          "anyOf": [
+                            {
+                              "properties": {
+                                "maxUnavailable": {
+                                  "anyOf": [
+                                    {
+                                      "properties": {
+                                        "Type": {
+                                          "type": "integer"
+                                        },
+                                        "IntVal": {
+                                          "type": "integer"
+                                        },
+                                        "StrVal": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                },
+                                "maxSurge": {
+                                  "anyOf": [
+                                    {
+                                      "properties": {
+                                        "Type": {
+                                          "type": "integer"
+                                        },
+                                        "IntVal": {
+                                          "type": "integer"
+                                        },
+                                        "StrVal": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "type": "object"
+                                    },
+                                    {
+                                      "type": "null"
+                                    }
+                                  ]
+                                }
+                              },
+                              "type": "object"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "minReadySeconds": {
+                      "type": "integer"
+                    },
+                    "revisionHistoryLimit": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "paused": {
+                      "type": "boolean"
+                    },
+                    "progressDeadlineSeconds": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "status": {
+                  "properties": {
+                    "observedGeneration": {
+                      "type": "integer"
+                    },
+                    "replicas": {
+                      "type": "integer"
+                    },
+                    "updatedReplicas": {
+                      "type": "integer"
+                    },
+                    "readyReplicas": {
+                      "type": "integer"
+                    },
+                    "availableReplicas": {
+                      "type": "integer"
+                    },
+                    "unavailableReplicas": {
+                      "type": "integer"
+                    },
+                    "conditions": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "type": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "lastUpdateTime": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "lastTransitionTime": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "collisionCount": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "serviceOverrides": {
+          "anyOf": [
+            {
+              "properties": {
+                "kind": {
+                  "type": "string"
+                },
+                "apiVersion": {
+                  "type": "string"
+                },
+                "metadata": {
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "generateName": {
+                      "type": "string"
+                    },
+                    "namespace": {
+                      "type": "string"
+                    },
+                    "selfLink": {
+                      "type": "string"
+                    },
+                    "uid": {
+                      "type": "string"
+                    },
+                    "resourceVersion": {
+                      "type": "string"
+                    },
+                    "generation": {
+                      "type": "integer"
+                    },
+                    "creationTimestamp": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deletionTimestamp": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "format": "date-time"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "deletionGracePeriodSeconds": {
+                      "anyOf": [
+                        {
+                          "type": "integer"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "labels": {
+                      "anyOf": [
+                        {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "annotations": {
+                      "anyOf": [
+                        {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "ownerReferences": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "kind": {
+                                "type": "string"
+                              },
+                              "name": {
+                                "type": "string"
+                              },
+                              "uid": {
+                                "type": "string"
+                              },
+                              "controller": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "blockOwnerDeletion": {
+                                "anyOf": [
+                                  {
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "finalizers": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "managedFields": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "manager": {
+                                "type": "string"
+                              },
+                              "operation": {
+                                "type": "string"
+                              },
+                              "apiVersion": {
+                                "type": "string"
+                              },
+                              "time": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "fieldsType": {
+                                "type": "string"
+                              },
+                              "fieldsV1": {
+                                "anyOf": [
+                                  {
+                                    "properties": {},
+                                    "type": "object"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "subresource": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "spec": {
+                  "properties": {
+                    "ports": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "type": "string"
+                              },
+                              "appProtocol": {
+                                "anyOf": [
+                                  {
+                                    "type": "string"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "port": {
+                                "type": "integer"
+                              },
+                              "targetPort": {
+                                "properties": {
+                                  "Type": {
+                                    "type": "integer"
+                                  },
+                                  "IntVal": {
+                                    "type": "integer"
+                                  },
+                                  "StrVal": {
+                                    "type": "string"
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "nodePort": {
+                                "type": "integer"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "selector": {
+                      "anyOf": [
+                        {
+                          "patternProperties": {
+                            ".*": {
+                              "type": "string"
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "clusterIP": {
+                      "type": "string"
+                    },
+                    "clusterIPs": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "externalIPs": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "sessionAffinity": {
+                      "type": "string"
+                    },
+                    "loadBalancerIP": {
+                      "type": "string"
+                    },
+                    "loadBalancerSourceRanges": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "externalName": {
+                      "type": "string"
+                    },
+                    "externalTrafficPolicy": {
+                      "type": "string"
+                    },
+                    "healthCheckNodePort": {
+                      "type": "integer"
+                    },
+                    "publishNotReadyAddresses": {
+                      "type": "boolean"
+                    },
+                    "sessionAffinityConfig": {
+                      "anyOf": [
+                        {
+                          "properties": {
+                            "clientIP": {
+                              "anyOf": [
+                                {
+                                  "properties": {
+                                    "timeoutSeconds": {
+                                      "anyOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "type": "null"
+                                        }
+                                      ]
+                                    }
+                                  },
+                                  "type": "object"
+                                },
+                                {
+                                  "type": "null"
+                                }
+                              ]
+                            }
+                          },
+                          "type": "object"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "ipFamilies": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "ipFamilyPolicy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "allocateLoadBalancerNodePorts": {
+                      "anyOf": [
+                        {
+                          "type": "boolean"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "loadBalancerClass": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "internalTrafficPolicy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                },
+                "status": {
+                  "properties": {
+                    "loadBalancer": {
+                      "properties": {
+                        "ingress": {
+                          "anyOf": [
+                            {
+                              "items": {
+                                "properties": {
+                                  "ip": {
+                                    "type": "string"
+                                  },
+                                  "hostname": {
+                                    "type": "string"
+                                  },
+                                  "ports": {
+                                    "anyOf": [
+                                      {
+                                        "items": {
+                                          "properties": {
+                                            "port": {
+                                              "type": "integer"
+                                            },
+                                            "protocol": {
+                                              "type": "string"
+                                            },
+                                            "error": {
+                                              "anyOf": [
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "null"
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          "type": "object"
+                                        },
+                                        "type": "array"
+                                      },
+                                      {
+                                        "type": "null"
+                                      }
+                                    ]
+                                  }
+                                },
+                                "type": "object"
+                              },
+                              "type": "array"
+                            },
+                            {
+                              "type": "null"
+                            }
+                          ]
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "conditions": {
+                      "anyOf": [
+                        {
+                          "items": {
+                            "properties": {
+                              "type": {
+                                "type": "string"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "observedGeneration": {
+                                "type": "integer"
+                              },
+                              "lastTransitionTime": {
+                                "anyOf": [
+                                  {
+                                    "type": "string",
+                                    "format": "date-time"
+                                  },
+                                  {
+                                    "type": "null"
+                                  }
+                                ]
+                              },
+                              "reason": {
+                                "type": "string"
+                              },
+                              "message": {
+                                "type": "string"
+                              }
+                            },
+                            "type": "object"
+                          },
+                          "type": "array"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    }
+  }
+}

--- a/codegen/test/chart/values.schema.json
+++ b/codegen/test/chart/values.schema.json
@@ -1,7 +1,7 @@
 {
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "properties": {
     "painter": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "image": {
           "properties": {

--- a/codegen/writer/writer.go
+++ b/codegen/writer/writer.go
@@ -43,15 +43,14 @@ func (w *DefaultFileWriter) WriteFiles(files []render.OutFile) error {
 
 		log.Printf("Writing %v", name)
 
-		commentPrefix := commentPrefixes[filepath.Ext(name)]
+		ext := filepath.Ext(name)
+		commentPrefix := commentPrefixes[ext]
 		if commentPrefix == "" {
 			// set default comment char to "#" as this is the most common
 			commentPrefix = "#"
 		}
 
-		if file.HeaderOverride != nil {
-			content = file.HeaderOverride.Generate() + content
-		} else if w.Header != "" {
+		if w.Header != "" && ext != ".json" {
 			content = fmt.Sprintf("%s %s\n\n", commentPrefix, w.Header) + content
 		}
 

--- a/codegen/writer/writer.go
+++ b/codegen/writer/writer.go
@@ -49,7 +49,9 @@ func (w *DefaultFileWriter) WriteFiles(files []render.OutFile) error {
 			commentPrefix = "#"
 		}
 
-		if w.Header != "" {
+		if file.HeaderOverride != nil {
+			content = file.HeaderOverride.Generate() + content
+		} else if w.Header != "" {
 			content = fmt.Sprintf("%s %s\n\n", commentPrefix, w.Header) + content
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,9 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/gnostic v0.5.7-v3refs
 	github.com/hashicorp/go-multierror v1.1.0
+	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0
 	github.com/iancoleman/strcase v0.1.3
+	github.com/invopop/jsonschema v0.7.0
 	github.com/lithammer/dedent v1.1.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/hashstructure v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -547,6 +547,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.0.0/go.mod h1:4qWG/gcEcfX4z/mBDHJ++3ReCw9ibxbsNJbcucJdbSo=
 github.com/huandu/xstrings v1.3.1 h1:4jgBlKK6tLKFvO8u5pmYjG91cqytmDCDvGh7ECVFfFs=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0 h1:i462o439ZjprVSFSZLZxcsoAe592sZB1rci2Z8j4wdk=
+github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0/go.mod h1:N0Wam8K1arqPXNWjMo21EXnBPOPp36vB07FNRdD2geA=
 github.com/iancoleman/strcase v0.0.0-20180726023541-3605ed457bf7/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/iancoleman/strcase v0.1.3 h1:dJBk1m2/qjL1twPLf68JND55vvivMupZ4wIzE8CTdBw=
@@ -561,6 +563,8 @@ github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/invopop/jsonschema v0.7.0 h1:2vgQcBz1n256N+FpX3Jq7Y17AjYt46Ig3zIWyy770So=
+github.com/invopop/jsonschema v0.7.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
@@ -886,6 +890,7 @@ github.com/stretchr/testify v0.0.0-20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRci
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.3.1-0.20190311161405-34c6fa2dc709/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=


### PR DESCRIPTION
Adds the ability to generate the json schema for a chart. Users will do this by adding the `JsonSchema` field to the chart definition as shown here:

https://github.com/solo-io/skv2/blob/33b1815a064e71bd033f148d63c323d5e60d95e4/codegen/cmd_test.go#L309


BOT NOTES: 
resolves https://github.com/solo-io/gloo-mesh-enterprise/issues/7186