### PR TITLE
fix input reconciler template

### DIFF
--- a/changelog/v0.29.5/fix-input-templates.yaml
+++ b/changelog/v0.29.5/fix-input-templates.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix compilation errors in input reconciler and input snapshot templates when running with k8s 1.25 libraries.
+    issueLink: https://github.com/solo-io/gloo/issues/6833

--- a/contrib/codegen/templates/input/input_reconciler.gotmpl
+++ b/contrib/codegen/templates/input/input_reconciler.gotmpl
@@ -153,7 +153,7 @@ func RegisterSingleCluster{{ $snapshotName }}Reconciler(
             Name:                 obj.Name,
             Namespace:            obj.Namespace,
             }
-            _, err := r.base.ReconcileLocalGeneric(ezkube.ConvertRefToId(ref))
+            _, err := r.base.ReconcileLocalGeneric(ref)
             return err
         },
     }, predicates...); err != nil {

--- a/contrib/codegen/templates/input/input_snapshot.gotmpl
+++ b/contrib/codegen/templates/input/input_snapshot.gotmpl
@@ -243,7 +243,7 @@ func (s *snapshot{{ $snapshotName }}) SyncStatusesMultiCluster(ctx context.Conte
     {{- if $resource.Status }}
     if opts.{{ $resource.Kind }} {
         for _, obj := range s.{{ $kindPlural }}().List() {
-            clusterClient, err := mcClient.Cluster(obj.ClusterName)
+            clusterClient, err := mcClient.Cluster(ezkube.GetClusterName(obj))
             if err != nil {
                 errs = multierror.Append(errs, err)
                 continue


### PR DESCRIPTION
Fix compilation errors in input reconciler and input snapshot templates when running with k8s 1.25 libraries.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6833