### PR TITLE
Manager multi version cache crds

### DIFF
--- a/pkg/multicluster/watch/watcher.go
+++ b/pkg/multicluster/watch/watcher.go
@@ -92,7 +92,7 @@ func NewClusterWatcher(ctx context.Context,
 // Option for the configuration of a clusterWatcher
 type Option func(*clusterWatcher)
 
-func (c *clusterWatcher) WithClusterOption(opts ...Option) {
+func WithClusterOption(c *clusterWatcher, opts ...Option) {
 	for _, opt := range opts {
 		opt(c)
 	}


### PR DESCRIPTION
Currently kubernetes managers will fail to start cache if they are missing any crds. https://github.com/kubernetes-sigs/controller-runtime/issues/1759

However when controlling many instances some which have older and some that have newer schemas we need some mechanism to not entirely stop working on the old ones. Customers pushed back on registering new CRDs on old clusters so this allows for an extended version of the manager.

As written this does not stop the reconciliation attempt on those clusters for the unknown CRDs which in turn will make the logs noisy BUT it does mean that if the remote clusters get upgraded to have the crd then we will start reconciling it immediatley.