### PR TITLE
Update cluster role binding to reference SA in operator namespace if provided

### DIFF
--- a/codegen/templates/chart/operator-rbac.yamltmpl
+++ b/codegen/templates/chart/operator-rbac.yamltmpl
@@ -25,7 +25,7 @@ Expressions evaluating SKv2 Config use [[ "[[" ]] and [[ "]]" ]]
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: [[ $operator.Name ]]-{{ .Release.Namespace }}
+  name: [[ $operator.Name ]]-{{ default .Release.Namespace [[ (opVar $operator) ]].namespace }}
   labels:
     app: [[ $operator.Name ]]
 rules:
@@ -36,16 +36,16 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: [[ $operator.Name ]]-{{ .Release.Namespace }}
+  name: [[ $operator.Name ]]-{{ default .Release.Namespace [[ (opVar $operator) ]].namespace }}
   labels:
     app: [[ $operator.Name ]]
 subjects:
 - kind: ServiceAccount
   name: [[ $operator.Name ]]
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ default .Release.Namespace [[ (opVar $operator) ]].namespace }}
 roleRef:
   kind: ClusterRole
-  name: [[ $operator.Name ]]-{{ .Release.Namespace }}
+  name: [[ $operator.Name ]]-{{ default .Release.Namespace [[ (opVar $operator) ]].namespace }}
   apiGroup: rbac.authorization.k8s.io
 
 {{- end }}


### PR DESCRIPTION
**Overview**
- This [PR](https://github.com/solo-io/skv2/pull/459) updated the operator deployment to install the deployment, service, and SA in the namespace specified in the values if provided.
- The ClusterRoleBinding was not updated which caused an issue as it was still referencing the SA as if it were deployed in the `{{ .Release.Namespace }}`. This PR updates the operator rbac yaml so the cluster role binding references the SA in the namespace specified in the values if it is provided