### PR TITLE
don't recurse on slice element

### DIFF
--- a/changelog/v0.31.2/slices.yaml
+++ b/changelog/v0.31.2/slices.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/10495
+    description: >
+      Don't generate docs entries for slice elements.

--- a/codegen/doc/helm_values.go
+++ b/codegen/doc/helm_values.go
@@ -137,8 +137,6 @@ func docReflect(addValue addValue, path []string, desc string, typ reflect.Type,
 
 		// add entry for slice field itself
 		addValue(HelmValue{Key: strings.Join(path, "."), Type: "[]" + typ.Elem().Kind().String(), DefaultValue: valToString(val), Description: desc})
-
-		docReflect(addValue, path, desc, typ.Elem(), reflect.Value{})
 	case reflect.Struct:
 
 		// add entry for struct field itself, ignoring the top level struct

--- a/codegen/doc/helm_values.go
+++ b/codegen/doc/helm_values.go
@@ -145,7 +145,8 @@ func docReflect(addValue addValue, path []string, desc string, typ reflect.Type,
 	case reflect.Struct:
 
 		// add entry for struct field itself, ignoring the top level struct
-		if len(path) > 0 {
+		// also ignore if the struct is inside a slice, since that was recorded in the slice entry
+		if len(path) > 0 && !strings.Contains(strings.Join(path, "."), "[]") {
 			addValue(HelmValue{Key: strings.Join(path, "."), Type: typ.Kind().String(), DefaultValue: " ", Description: desc})
 		}
 

--- a/codegen/doc/helm_values.go
+++ b/codegen/doc/helm_values.go
@@ -137,6 +137,11 @@ func docReflect(addValue addValue, path []string, desc string, typ reflect.Type,
 
 		// add entry for slice field itself
 		addValue(HelmValue{Key: strings.Join(path, "."), Type: "[]" + typ.Elem().Kind().String(), DefaultValue: valToString(val), Description: desc})
+
+		// if element is a struct, recurse
+		if typ.Elem().Kind() == reflect.Struct {
+			docReflect(addValue, path, desc, typ.Elem(), reflect.Value{})
+		}
 	case reflect.Struct:
 
 		// add entry for struct field itself, ignoring the top level struct

--- a/codegen/doc/helm_values.go
+++ b/codegen/doc/helm_values.go
@@ -138,8 +138,8 @@ func docReflect(addValue addValue, path []string, desc string, typ reflect.Type,
 		// add entry for slice field itself
 		addValue(HelmValue{Key: strings.Join(path, "."), Type: "[]" + typ.Elem().Kind().String(), DefaultValue: valToString(val), Description: desc})
 
-		// if element is a struct, recurse
-		if typ.Elem().Kind() == reflect.Struct {
+		// if element is a struct or pointer, recurse
+		if typ.Elem().Kind() == reflect.Struct || typ.Elem().Kind() == reflect.Ptr {
 			docReflect(addValue, path, desc, typ.Elem(), reflect.Value{})
 		}
 	case reflect.Struct:

--- a/codegen/doc/helm_values_test.go
+++ b/codegen/doc/helm_values_test.go
@@ -151,12 +151,6 @@ var _ = Describe("GenerateHelmValuesDoc", func() {
 				Description:  "child type",
 			},
 			{
-				Key:          "test.childType[]",
-				Type:         "struct",
-				DefaultValue: " ",
-				Description:  "child type",
-			},
-			{
 				Key:          "test.childType[].myCoolField[]",
 				Type:         "[]string",
 				DefaultValue: " ",

--- a/codegen/doc/helm_values_test.go
+++ b/codegen/doc/helm_values_test.go
@@ -112,11 +112,15 @@ var _ = Describe("GenerateHelmValuesDoc", func() {
 	})
 
 	It("handles slices of structs", func() {
+		type Nested struct {
+			Nest []int
+		}
 		type ChildType2 struct {
 			Field2 string `json:"myCoolField2" desc:"my field 2"`
 		}
 		type ChildType struct {
-			Field1 []string `json:"myCoolField" desc:"my field"`
+			Field1 []string  `json:"myCoolField" desc:"my field"`
+			Nested []*Nested `json:"nested" desc:"nested struct"`
 		}
 		type Parent struct {
 			ChildType  []ChildType `json:"childType" desc:"child type"`
@@ -126,6 +130,14 @@ var _ = Describe("GenerateHelmValuesDoc", func() {
 			ChildType: []ChildType{
 				{
 					Field1: []string{"default"},
+					Nested: []*Nested{
+						{
+							Nest: []int{1, 2, 3},
+						},
+						{
+							Nest: []int{4, 5, 6},
+						},
+					},
 				},
 			},
 			ChildType2: ChildType2{
@@ -147,7 +159,7 @@ var _ = Describe("GenerateHelmValuesDoc", func() {
 			{
 				Key:          "test.childType[]",
 				Type:         "[]struct",
-				DefaultValue: "[{\"myCoolField\":[\"default\"]}]",
+				DefaultValue: "[{\"myCoolField\":[\"default\"],\"nested\":[{\"Nest\":[1,2,3]},{\"Nest\":[4,5,6]}]}]",
 				Description:  "child type",
 			},
 			{
@@ -155,6 +167,18 @@ var _ = Describe("GenerateHelmValuesDoc", func() {
 				Type:         "[]string",
 				DefaultValue: " ",
 				Description:  "my field",
+			},
+			{
+				Key:          "test.childType[].nested[]",
+				Type:         "[]ptr",
+				DefaultValue: " ",
+				Description:  "nested struct",
+			},
+			{
+				Key:          "test.childType[].nested[][]",
+				Type:         "[]int",
+				DefaultValue: " ",
+				Description:  "",
 			},
 			{
 				Key:          "test.childType2",


### PR DESCRIPTION
Only recurse on slice element if it's a struct or pointer.
Ignore adding a value for a struct within a slice, since that is handled when adding the slice.

see https://github.com/solo-io/gloo-mesh-enterprise/pull/10511 for outcome
BOT NOTES: 
resolves https://github.com/solo-io/gloo-mesh-enterprise/issues/10495