### PR TITLE
v0.29.x: Fix bug in skv2 UpdateStatusImmutable

### DIFF
--- a/changelog/v0.29.11/copy-metadata-on-status-upsert.yaml
+++ b/changelog/v0.29.11/copy-metadata-on-status-upsert.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      "Copy metadata from the existing object to the upserted object when upserting a status."

--- a/pkg/controllerutils/upsert.go
+++ b/pkg/controllerutils/upsert.go
@@ -142,6 +142,8 @@ func UpdateStatusImmutable(
 
 	// https://github.com/solo-io/skv2/issues/344
 	copyOfObj.SetUID(existing.GetUID())
+	copyOfObj.SetCreationTimestamp(existing.GetCreationTimestamp())
+	copyOfObj.SetResourceVersion(existing.GetResourceVersion())
 
 	return update(ctx, c, copyOfObj)
 }


### PR DESCRIPTION
when we DeepCopy the object in this method, we do not set the creation timestamp or resource version to match the existing object. This triggers extra reconciles from a status update which should not occur.