### PR TITLE
operator rbac template bug fix

### DIFF
--- a/codegen/templates/chart/operator-rbac.yamltmpl
+++ b/codegen/templates/chart/operator-rbac.yamltmpl
@@ -11,7 +11,7 @@ Expressions evaluating SKv2 Config use [[ "[[" ]] and [[ "]]" ]]
 
 {{- $[[ $operatorVar ]] := [[ (opVar $operator)]] }}
 
-[[- $operatorEnabledCondition := printf "\n{{- if $%s.enabled -}}\n" $operatorVar -]]
+[[- $operatorEnabledCondition := printf "\n{{- if $%s.enabled }}\n" $operatorVar -]]
 [[- if (gt (len $operator.CustomEnableCondition) 0) -]]
 [[- $operatorEnabledCondition = printf "\n{{- if %s }}\n" $operator.CustomEnableCondition -]]
 [[- end -]]


### PR DESCRIPTION
Removes `-` character in if statement template block that was causing trailing whitespace issues.

Found in v0.31.x backport so introducing change here.