### PR TITLE
increase proto import timeout; bump golang to 1.21.1

### DIFF
--- a/changelog/v0.34.5/bump-proto-imports-timeout.yaml
+++ b/changelog/v0.34.5/bump-proto-imports-timeout.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: golang
+    dependencyRepo: golang
+    dependencyTag: v1.21.1
+  - type: NON_USER_FACING
+    issueLink:   https://github.com/solo-io/gloo-mesh-enterprise/issues/11090
+    description: >
+      Bump time before declaring a deadlock when processing proto imports to 15s instead of 5s. 
+    resolvesIssue: false

--- a/codegen/collector/extractor.go
+++ b/codegen/collector/extractor.go
@@ -87,9 +87,10 @@ func (i *synchronizedImportsExtractor) FetchImportsForFile(protoFile string, imp
 	i.activeRequestsMu.Unlock()
 
 	select {
-	case <-time.After(5 * time.Second):
-		// We should never reach this. This can only occur if we deadlock on file imports
-		// which only happens with cyclic dependencies
+	case <-time.After(15 * time.Second):
+		// We should never reach this in an ideal scenario. If we do, it means that
+		// we either have a deadlock or golang is being very slow.
+		// The deadlock occurs on file imports with cyclic dependencies.
 		// Perhaps a safer alternative to erroring is just to execute the importsFetcher:
 		// 	return importsFetcher(protoFile)
 		return nil, FetchImportsTimeout(protoFile)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/skv2
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/skv2
 
-go 1.20
+go 1.21.1
 
 require (
 	github.com/BurntSushi/toml v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -537,6 +537,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -870,6 +871,7 @@ go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=


### PR DESCRIPTION
In bumping golang to 1.21 in `gloo-mesh-enterprise` (https://github.com/solo-io/gloo-mesh-enterprise/pull/11169) we saw consistent timeout issues with codegen only in CI that looked like this:

```
{
    "duration": {
        "@code-generator/proto-compiler": "9.691022611s"
generate.go:49: 9 errors occurred:
	* Timed out while fetching imports for proto file: [/home/runner/work/gloo-mesh-enterprise/gloo-mesh-enterprise/vendor_any/github.com/solo-io/gloo-mesh-enterprise/api/gloo.solo.io/admin/v2alpha1/waypoint_lifecycle_manager.proto]
    },
	* Timed out while fetching imports for proto file: [/home/runner/work/gloo-mesh-enterprise/gloo-mesh-enterprise/vendor_any/github.com/solo-io/gloo-mesh-enterprise/api/gloo.solo.io/apimanagement/v2/portal.proto]
    "frequency": {
	* Timed out while fetching imports for proto file: [/home/runner/work/gloo-mesh-enterprise/gloo-mesh-enterprise/vendor_any/github.com/solo-io/gloo-mesh-enterprise/api/gloo.solo.io/admin/v2/gateway_lifecycle_manager.proto]
        "@code-generator/collector-opened-files": 241
	* Timed out while fetching imports for proto file: [/home/runner/work/gloo-mesh-enterprise/gloo-mesh-enterprise/vendor_any/github.com/solo-io/gloo-mesh-enterprise/api/gloo.solo.io/admin/v2/istio_lifecycle_manager.proto]
    }
	* Timed out while fetching imports for proto file: [/home/runner/work/gloo-mesh-enterprise/gloo-mesh-enterprise/vendor_any/github.com/solo-io/gloo-mesh-enterprise/api/gloo.solo.io/admin/v2/ratelimit_server_config.proto]
	* Timed out while fetching imports for proto file: [/home/runner/work/gloo-mesh-enterprise/gloo-mesh-enterprise/vendor_any/github.com/solo-io/gloo-mesh-enterprise/api/gloo.solo.io/policy/v2/security/ext_auth_policy.proto]
	* Timed out while fetching imports for proto file: [/home/runner/work/gloo-mesh-enterprise/gloo-mesh-enterprise/vendor_any/github.com/solo-io/gloo-mesh-enterprise/api/gloo.solo.io/networking/v2/route_table.proto]
	* Timed out while fetching imports for proto file: [/home/runner/work/gloo-mesh-enterprise/gloo-mesh-enterprise/vendor_any/github.com/solo-io/solo-apis/api/gloo/enterprise.gloo/v1/auth_config.proto]
	* Timed out while fetching imports for proto file: [/home/runner/work/gloo-mesh-enterprise/gloo-mesh-enterprise/vendor_any/github.com/solo-io/solo-kit/api/external/envoy/api/v2/discovery.proto]
```

To resolve, I traced the issue back to skv2 and realized that we had a hard-coded 5 second limit for resolving proto imports. The code in this repo indicated that this error was only possible with circular dependencies, but since I could successfully compile our protos locally I increased the timeout to 15s and it worked as expected. I'm not sure of the root cause here - likely a performance regression in go1.21 or some of the related toolchain, but we need to resolve this for now so we can complete the upgrade. I also bumped go to 1.21.1 in this repo so that the projects are using the same golang versions.