### PR TITLE
codegen: remove conditional enabling of internal CRDs

### DIFF
--- a/changelog/v0.34.8/render-internalalpha.yaml
+++ b/changelog/v0.34.8/render-internalalpha.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: |
+      Don't conditionally enable internal CRDs. Internal CRDs are an implementation detail that should not be exposed to end users to toggle.
+    skipCI: false

--- a/codegen/render/funcs.go
+++ b/codegen/render/funcs.go
@@ -33,6 +33,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+const (
+	internalCRDGroupName = "internal.gloo.solo.io"
+)
+
 func makeTemplateFuncs(customFuncs template.FuncMap) template.FuncMap {
 	f := sprig.TxtFuncMap()
 
@@ -135,11 +139,11 @@ func makeTemplateFuncs(customFuncs template.FuncMap) template.FuncMap {
 		"opVar":            opVar,
 
 		"render_outer_conditional_crd_template": func(crd kuberesource.GlooCustomResourceDefinition, currentVersion string, skips map[string]bool) bool {
-			return len(crd.Spec.Versions) < 2 && strings.Contains(currentVersion, "alpha") && !skips[crd.Spec.Group+"/"+currentVersion]
+			return len(crd.Spec.Versions) < 2 && strings.Contains(currentVersion, "alpha") && !strings.Contains(crd.Spec.Group, internalCRDGroupName) && !skips[crd.Spec.Group+"/"+currentVersion]
 		},
 
 		"render_inner_conditional_crd_template": func(crd kuberesource.GlooCustomResourceDefinition, currentVersion string, skips map[string]bool) bool {
-			return len(crd.Spec.Versions) > 1 && strings.Contains(currentVersion, "alpha") && !skips[crd.Spec.Group+"/"+currentVersion]
+			return len(crd.Spec.Versions) > 1 && strings.Contains(currentVersion, "alpha") && !strings.Contains(crd.Spec.Group, internalCRDGroupName) && !skips[crd.Spec.Group+"/"+currentVersion]
 		},
 	}
 
@@ -572,7 +576,6 @@ func mergeNodes(nodes ...goyaml.Node) goyaml.Node {
 	}
 	if mergedNode.IsZero() {
 		panic("all nodes were found to be IsZero, cannot continue")
-
 	}
 	return mergedNode
 }
@@ -964,7 +967,6 @@ func mergeJsonSchema(
 	target *jsonschema.Schema,
 	src *jsonschema.Schema,
 ) {
-
 	if target.Required == nil {
 		target.Required = []string{}
 	}


### PR DESCRIPTION
Internal CRDs are an implementation detail and must not be exposed to end users to enable/disable.