### PR TITLE
Fix AppendingErrHandler issue causing errors not to be stored in passed down handlers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# Description
+
+Please include a thorough summary of the changes.
+
+This fixes ... \ This new feature can be used to ...
+
+# Context
+
+Summary of issue
+
+Description and justification of any interesting decisions made

--- a/changelog/v0.35.0/fix-AppendErrHandler-not-appending-errors-to-original-object.yaml
+++ b/changelog/v0.35.0/fix-AppendErrHandler-not-appending-errors-to-original-object.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/skv2/issues/517
+    description: Fix issue where the AppendErrHandler was not appending errors to the original object.
+  - type: BREAKING_CHANGE
+    issueLink: https://github.com/solo-io/skv2/issues/517
+    description: Usages of AppendErrHandler will now need to pass it by reference (&).

--- a/contrib/pkg/output/errhandlers/err_handlers.go
+++ b/contrib/pkg/output/errhandlers/err_handlers.go
@@ -9,20 +9,30 @@ import (
 
 // this file contains ErrorHandlers for handling errors created when writing output snapshots
 
+func ResourceWriteError(resource ezkube.Object, err error) error {
+	return eris.Wrapf(err, "writing resource %v failed", sets.Key(resource))
+}
+func ResourceDeleteError(resource ezkube.Object, err error) error {
+	return eris.Wrapf(err, "deleting resource %v failed", sets.Key(resource))
+}
+func ListError(err error) error {
+	return eris.Wrapf(err, "listing failed")
+}
+
 type AppendingErrHandler struct {
 	errs error
 }
 
 func (a *AppendingErrHandler) HandleWriteError(resource ezkube.Object, err error) {
-	a.errs = multierror.Append(a.errs, eris.Wrapf(err, "writing resource %v failed", sets.Key(resource)))
+	a.errs = multierror.Append(a.errs, ResourceWriteError(resource, err))
 }
 
 func (a *AppendingErrHandler) HandleDeleteError(resource ezkube.Object, err error) {
-	a.errs = multierror.Append(a.errs, eris.Wrapf(err, "deleting resource %v failed", sets.Key(resource)))
+	a.errs = multierror.Append(a.errs, ResourceDeleteError(resource, err))
 }
 
 func (a *AppendingErrHandler) HandleListError(err error) {
-	a.errs = multierror.Append(a.errs, eris.Wrapf(err, "listing failed"))
+	a.errs = multierror.Append(a.errs, ListError(err))
 }
 
 // returns the errors collected by the handler

--- a/contrib/pkg/output/errhandlers/err_handlers.go
+++ b/contrib/pkg/output/errhandlers/err_handlers.go
@@ -16,7 +16,7 @@ func ResourceDeleteError(resource ezkube.Object, err error) error {
 	return eris.Wrapf(err, "deleting resource %v failed", sets.Key(resource))
 }
 func ListError(err error) error {
-	return eris.Wrapf(err, "listing failed")
+	return eris.Wrapf(err, "listing resources failed")
 }
 
 type AppendingErrHandler struct {

--- a/contrib/pkg/output/errhandlers/err_handlers.go
+++ b/contrib/pkg/output/errhandlers/err_handlers.go
@@ -35,7 +35,7 @@ func (a *AppendingErrHandler) HandleListError(err error) {
 	a.errs = multierror.Append(a.errs, ListError(err))
 }
 
-// returns the errors collected by the handler
+// Errors returns the errors collected by the handler
 func (a *AppendingErrHandler) Errors() error {
 	return a.errs
 }

--- a/contrib/pkg/output/errhandlers/err_handlers.go
+++ b/contrib/pkg/output/errhandlers/err_handlers.go
@@ -13,19 +13,19 @@ type AppendingErrHandler struct {
 	errs error
 }
 
-func (a AppendingErrHandler) HandleWriteError(resource ezkube.Object, err error) {
+func (a *AppendingErrHandler) HandleWriteError(resource ezkube.Object, err error) {
 	a.errs = multierror.Append(a.errs, eris.Wrapf(err, "writing resource %v failed", sets.Key(resource)))
 }
 
-func (a AppendingErrHandler) HandleDeleteError(resource ezkube.Object, err error) {
+func (a *AppendingErrHandler) HandleDeleteError(resource ezkube.Object, err error) {
 	a.errs = multierror.Append(a.errs, eris.Wrapf(err, "deleting resource %v failed", sets.Key(resource)))
 }
 
-func (a AppendingErrHandler) HandleListError(err error) {
+func (a *AppendingErrHandler) HandleListError(err error) {
 	a.errs = multierror.Append(a.errs, eris.Wrapf(err, "listing failed"))
 }
 
 // returns the errors collected by the handler
-func (a AppendingErrHandler) Errors() error {
+func (a *AppendingErrHandler) Errors() error {
 	return a.errs
 }

--- a/contrib/pkg/output/errhandlers/err_handlers_suite_test.go
+++ b/contrib/pkg/output/errhandlers/err_handlers_suite_test.go
@@ -1,0 +1,13 @@
+package errhandlers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCodegen(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Error Handlers Suite")
+}

--- a/contrib/pkg/output/errhandlers/err_handlers_test.go
+++ b/contrib/pkg/output/errhandlers/err_handlers_test.go
@@ -56,13 +56,13 @@ var _ = Describe("Error Handlers", func() {
 type errorMutation func(handler output.ErrorHandler, resource ezkube.Object)
 
 func addListError(handler output.ErrorHandler, _ ezkube.Object) {
-	handler.HandleListError(errors.New(""))
+	handler.HandleListError(errors.New("listing resources failed"))
 }
 func addWriteError(handler output.ErrorHandler, resource ezkube.Object) {
-	handler.HandleWriteError(resource, errors.New(""))
+	handler.HandleWriteError(resource, errors.New("writing resource failed"))
 }
 func addDeleteError(handler output.ErrorHandler, resource ezkube.Object) {
-	handler.HandleDeleteError(resource, errors.New(""))
+	handler.HandleDeleteError(resource, errors.New("deleting resource failed"))
 }
 
 // errorExpectation is a function that expects a specific error to occur

--- a/contrib/pkg/output/errhandlers/err_handlers_test.go
+++ b/contrib/pkg/output/errhandlers/err_handlers_test.go
@@ -1,0 +1,94 @@
+package errhandlers
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	v1 "github.com/solo-io/skv2/codegen/test/api/things.test.io/v1"
+	"github.com/solo-io/skv2/contrib/pkg/output"
+	"github.com/solo-io/skv2/pkg/ezkube"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Error Handlers", func() {
+	var (
+		errorHandler output.ErrorHandler
+		fakeResource = &v1.Paint{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake-name",
+				Namespace: "fake-ns",
+			},
+		}
+	)
+
+	Context("AppendingErrHandler", func() {
+		BeforeEach(func() {
+			errorHandler = &AppendingErrHandler{}
+		})
+
+		DescribeTable("should append errors to the error handler object", func(mutation errorMutation, expects errorExpectation) {
+			mutation(errorHandler, fakeResource)
+			expects(errorHandler.(*AppendingErrHandler).Errors(), fakeResource)
+		},
+			Entry("when HandleListError is called", addListError, expectListError),
+			Entry("when HandleWriteError is called", addWriteError, expectWriteError),
+			Entry("when HandleDeleteError is called", addDeleteError, expectDeleteError),
+			Entry("when multiple error handler functions are invoked", func(handler output.ErrorHandler, resource ezkube.Object) {
+				addListError(handler, resource)
+				addWriteError(handler, resource)
+				addDeleteError(handler, resource)
+			}, func(err error, resource ezkube.Object) {
+				Expect(err).To(And(
+					MatchError(ListError(err)),
+					MatchError(ResourceWriteError(resource, err)),
+					MatchError(ResourceDeleteError(resource, err)),
+				))
+			}),
+		)
+
+		It("should not have an error when no errors occur", func() {
+			errs := errorHandler.(*AppendingErrHandler).Errors()
+			Expect(errs).NotTo(HaveOccurred())
+		})
+	})
+})
+
+type errorMutation func(handler output.ErrorHandler, resource ezkube.Object)
+
+func addListError(handler output.ErrorHandler, _ ezkube.Object) {
+	handler.HandleListError(errors.New(""))
+}
+func addWriteError(handler output.ErrorHandler, resource ezkube.Object) {
+	handler.HandleWriteError(resource, errors.New(""))
+}
+func addDeleteError(handler output.ErrorHandler, resource ezkube.Object) {
+	handler.HandleDeleteError(resource, errors.New(""))
+}
+
+// errorExpectation is a function that expects a specific error to occur
+type errorExpectation func(err error, resource ezkube.Object)
+
+func expectListError(err error, resource ezkube.Object) {
+	Expect(err).To(HaveOccurred())
+	Expect(err).To(And(
+		MatchError(ListError(err)),
+		Not(MatchError(ResourceWriteError(resource, err))),
+		Not(MatchError(ResourceDeleteError(resource, err))),
+	))
+}
+func expectWriteError(err error, resource ezkube.Object) {
+	Expect(err).To(HaveOccurred())
+	Expect(err).To(And(
+		MatchError(ResourceWriteError(resource, err)),
+		Not(MatchError(ListError(err))),
+		Not(MatchError(ResourceDeleteError(resource, err))),
+	))
+}
+func expectDeleteError(err error, resource ezkube.Object) {
+	Expect(err).To(HaveOccurred())
+	Expect(err).To(And(
+		MatchError(ResourceDeleteError(resource, err)),
+		Not(MatchError(ListError(err))),
+		Not(MatchError(ResourceWriteError(resource, err))),
+	))
+}

--- a/contrib/pkg/output/errhandlers/err_handlers_test.go
+++ b/contrib/pkg/output/errhandlers/err_handlers_test.go
@@ -69,24 +69,24 @@ func addDeleteError(handler output.ErrorHandler, resource ezkube.Object) {
 type errorExpectation func(err error, resource ezkube.Object)
 
 func expectListError(err error, resource ezkube.Object) {
-	Expect(err).To(HaveOccurred())
-	Expect(err).To(And(
+	ExpectWithOffset(1, err).To(HaveOccurred())
+	ExpectWithOffset(1, err).To(And(
 		MatchError(ListError(err)),
 		Not(MatchError(ResourceWriteError(resource, err))),
 		Not(MatchError(ResourceDeleteError(resource, err))),
 	))
 }
 func expectWriteError(err error, resource ezkube.Object) {
-	Expect(err).To(HaveOccurred())
-	Expect(err).To(And(
+	ExpectWithOffset(1, err).To(HaveOccurred())
+	ExpectWithOffset(1, err).To(And(
 		MatchError(ResourceWriteError(resource, err)),
 		Not(MatchError(ListError(err))),
 		Not(MatchError(ResourceDeleteError(resource, err))),
 	))
 }
 func expectDeleteError(err error, resource ezkube.Object) {
-	Expect(err).To(HaveOccurred())
-	Expect(err).To(And(
+	ExpectWithOffset(1, err).To(HaveOccurred())
+	ExpectWithOffset(1, err).To(And(
 		MatchError(ResourceDeleteError(resource, err)),
 		Not(MatchError(ListError(err))),
 		Not(MatchError(ResourceWriteError(resource, err))),


### PR DESCRIPTION
# Changes

- Use a pointer receiver for `AppendErrorHandler`
- Add unit tests to make sure `AppendErrorHandler` works as expected (appending errors)
  - without the AppendingErrorHandler being a pointer receiver -> the tests will fail.
- Add very simple pull request template to add information regarding changes + context.

# Context

This was caught while debugging an issue in Portal. A failed `upsert` did not result in a `State: Failed` in Portal due to no errors in the `AppendingErrHandler`.

From more debugging I noticed that the `AppendingErrHandler` did have the expected error during `syncList` [here](https://github.com/solo-io/skv2/blob/3055431e9667ff6b93cac0b4ba5f64843c10566a/contrib/pkg/output/snapshot.go#L300-L306), but the error did not propagate upwards to `SyncLocalCluster` [here](https://github.com/solo-io/skv2/blob/3055431e9667ff6b93cac0b4ba5f64843c10566a/contrib/pkg/output/snapshot.go#L238).

This was due to reference vs value/copy modifications, where in this case the `errHandler` stored the error in a _copy_ of the object instead of the object itself. Updating the `AppendingErrHandler` methods to use `*AppendingErrHandler` fixed the issue.

BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/517