### PR TITLE
back: proto timeout

### DIFF
--- a/changelog/v0.26.3/proto-import-timeout.yaml
+++ b/changelog/v0.26.3/proto-import-timeout.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Bump time before declaring a deadlock when processing proto imports to 15s instead of 5s. 
+      Backport of https://github.com/solo-io/skv2/commit/38333ccb2e5e779973ad94354ec499932749fed0

--- a/codegen/collector/extractor.go
+++ b/codegen/collector/extractor.go
@@ -87,9 +87,10 @@ func (i *synchronizedImportsExtractor) FetchImportsForFile(protoFile string, imp
 	i.activeRequestsMu.Unlock()
 
 	select {
-	case <-time.After(5 * time.Second):
-		// We should never reach this. This can only occur if we deadlock on file imports
-		// which only happens with cyclic dependencies
+	case <-time.After(15 * time.Second):
+		// We should never reach this in an ideal scenario. If we do, it means that
+		// we either have a deadlock or golang is being very slow.
+		// The deadlock occurs on file imports with cyclic dependencies.
 		// Perhaps a safer alternative to erroring is just to execute the importsFetcher:
 		// 	return importsFetcher(protoFile)
 		return nil, FetchImportsTimeout(protoFile)


### PR DESCRIPTION
Backport proto timing, its not runtime just ci / dev tooling times

backport of the parts without go bump https://github.com/solo-io/skv2/commit/38333ccb2e5e779973ad94354ec499932749fed0