### PR TITLE
add TargetRefWithSectionName

### DIFF
--- a/api/core/v1/core.proto
+++ b/api/core/v1/core.proto
@@ -162,3 +162,22 @@ message ObjectSelector {
     }
 }
 
+// TargetRef identifies Gateway API objects to apply a direct policy to.
+// This is a copy of the upstream K8s Gateway API `targetRef` API.
+// Note that we are only using the upstream `PolicyTargetReferenceWithSectionName` type as currently our policies will distinguish between sections.
+// See the following for more information:
+// * https://gateway-api.sigs.k8s.io/geps/gep-713/
+// * https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.PolicyTargetReferenceWithSectionName
+// * https://github.com/kubernetes-sigs/gateway-api/blob/444631bfe06f3bcca5d0eadf1857eac1d369421d/apis/v1alpha2/policy_types.go#L58-L83
+message TargetRefWithSectionName {
+  string group = 1;
+  string kind = 2;
+  string name = 3;
+
+  // Optional, if unspecified, the local namespace of the policy is inferred.
+  google.protobuf.StringValue namespace = 4;
+
+  // Name of the section within the targeted resource to attach to. For `Gateway` resources, this refers to a `Listener` name.
+  // Optional, if unspecified, the entire object referenced is selected.
+  google.protobuf.StringValue section_name = 5;
+}

--- a/changelog/v0.36.3/add-target-ref.yaml
+++ b/changelog/v0.36.3/add-target-ref.yaml
@@ -1,3 +1,4 @@
 changelog:
   - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/skv2/issues/529
     description: Add clone of TargetRef API from upstream K8s Gateway API

--- a/changelog/v0.36.3/add-target-ref.yaml
+++ b/changelog/v0.36.3/add-target-ref.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Add clone of TargetRef API from upstream K8s Gateway API

--- a/pkg/api/core.skv2.solo.io/v1/core.pb.clone.go
+++ b/pkg/api/core.skv2.solo.io/v1/core.pb.clone.go
@@ -213,6 +213,35 @@ func (m *ObjectSelector) Clone() proto.Message {
 }
 
 // Clone function
+func (m *TargetRefWithSectionName) Clone() proto.Message {
+	var target *TargetRefWithSectionName
+	if m == nil {
+		return target
+	}
+	target = &TargetRefWithSectionName{}
+
+	target.Group = m.GetGroup()
+
+	target.Kind = m.GetKind()
+
+	target.Name = m.GetName()
+
+	if h, ok := interface{}(m.GetNamespace()).(clone.Cloner); ok {
+		target.Namespace = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+	} else {
+		target.Namespace = proto.Clone(m.GetNamespace()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+	}
+
+	if h, ok := interface{}(m.GetSectionName()).(clone.Cloner); ok {
+		target.SectionName = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+	} else {
+		target.SectionName = proto.Clone(m.GetSectionName()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+	}
+
+	return target
+}
+
+// Clone function
 func (m *ObjectSelector_Expression) Clone() proto.Message {
 	var target *ObjectSelector_Expression
 	if m == nil {

--- a/pkg/api/core.skv2.solo.io/v1/core.pb.equal.go
+++ b/pkg/api/core.skv2.solo.io/v1/core.pb.equal.go
@@ -362,6 +362,62 @@ func (m *ObjectSelector) Equal(that interface{}) bool {
 }
 
 // Equal function
+func (m *TargetRefWithSectionName) Equal(that interface{}) bool {
+	if that == nil {
+		return m == nil
+	}
+
+	target, ok := that.(*TargetRefWithSectionName)
+	if !ok {
+		that2, ok := that.(TargetRefWithSectionName)
+		if ok {
+			target = &that2
+		} else {
+			return false
+		}
+	}
+	if target == nil {
+		return m == nil
+	} else if m == nil {
+		return false
+	}
+
+	if strings.Compare(m.GetGroup(), target.GetGroup()) != 0 {
+		return false
+	}
+
+	if strings.Compare(m.GetKind(), target.GetKind()) != 0 {
+		return false
+	}
+
+	if strings.Compare(m.GetName(), target.GetName()) != 0 {
+		return false
+	}
+
+	if h, ok := interface{}(m.GetNamespace()).(equality.Equalizer); ok {
+		if !h.Equal(target.GetNamespace()) {
+			return false
+		}
+	} else {
+		if !proto.Equal(m.GetNamespace(), target.GetNamespace()) {
+			return false
+		}
+	}
+
+	if h, ok := interface{}(m.GetSectionName()).(equality.Equalizer); ok {
+		if !h.Equal(target.GetSectionName()) {
+			return false
+		}
+	} else {
+		if !proto.Equal(m.GetSectionName(), target.GetSectionName()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Equal function
 func (m *ObjectSelector_Expression) Equal(that interface{}) bool {
 	if that == nil {
 		return m == nil

--- a/pkg/api/core.skv2.solo.io/v1/core.pb.go
+++ b/pkg/api/core.skv2.solo.io/v1/core.pb.go
@@ -654,6 +654,95 @@ func (x *ObjectSelector) GetExpressions() []*ObjectSelector_Expression {
 	return nil
 }
 
+// TargetRef identifies Gateway API objects to apply a direct policy to.
+// This is a copy of the upstream K8s Gateway API `targetRef` API.
+// Note that we are only using the upstream `PolicyTargetReferenceWithSectionName` type as currently our policies will distinguish between sections.
+// See the following for more information:
+// * https://gateway-api.sigs.k8s.io/geps/gep-713/
+// * https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.PolicyTargetReferenceWithSectionName
+// * https://github.com/kubernetes-sigs/gateway-api/blob/444631bfe06f3bcca5d0eadf1857eac1d369421d/apis/v1alpha2/policy_types.go#L58-L83
+type TargetRefWithSectionName struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Group string `protobuf:"bytes,1,opt,name=group,proto3" json:"group,omitempty"`
+	Kind  string `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Name  string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	// Optional, if unspecified, the local namespace of the policy is inferred.
+	Namespace *wrappers.StringValue `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// Name of the section within the targeted resource to attach to. For `Gateway` resources, this refers to a `Listener` name.
+	// Optional, if unspecified, the entire object referenced is selected.
+	SectionName *wrappers.StringValue `protobuf:"bytes,5,opt,name=section_name,json=sectionName,proto3" json:"section_name,omitempty"`
+}
+
+func (x *TargetRefWithSectionName) Reset() {
+	*x = TargetRefWithSectionName{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[7]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TargetRefWithSectionName) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TargetRefWithSectionName) ProtoMessage() {}
+
+func (x *TargetRefWithSectionName) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[7]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TargetRefWithSectionName.ProtoReflect.Descriptor instead.
+func (*TargetRefWithSectionName) Descriptor() ([]byte, []int) {
+	return file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *TargetRefWithSectionName) GetGroup() string {
+	if x != nil {
+		return x.Group
+	}
+	return ""
+}
+
+func (x *TargetRefWithSectionName) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *TargetRefWithSectionName) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *TargetRefWithSectionName) GetNamespace() *wrappers.StringValue {
+	if x != nil {
+		return x.Namespace
+	}
+	return nil
+}
+
+func (x *TargetRefWithSectionName) GetSectionName() *wrappers.StringValue {
+	if x != nil {
+		return x.SectionName
+	}
+	return nil
+}
+
 type ObjectSelector_Expression struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -670,7 +759,7 @@ type ObjectSelector_Expression struct {
 func (x *ObjectSelector_Expression) Reset() {
 	*x = ObjectSelector_Expression{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[8]
+		mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[9]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -683,7 +772,7 @@ func (x *ObjectSelector_Expression) String() string {
 func (*ObjectSelector_Expression) ProtoMessage() {}
 
 func (x *ObjectSelector_Expression) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[8]
+	mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[9]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -826,12 +915,26 @@ var file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDesc = []byte{
 	0x10, 0x04, 0x12, 0x0a, 0x0a, 0x06, 0x45, 0x78, 0x69, 0x73, 0x74, 0x73, 0x10, 0x05, 0x12, 0x10,
 	0x0a, 0x0c, 0x44, 0x6f, 0x65, 0x73, 0x4e, 0x6f, 0x74, 0x45, 0x78, 0x69, 0x73, 0x74, 0x10, 0x06,
 	0x12, 0x0f, 0x0a, 0x0b, 0x47, 0x72, 0x65, 0x61, 0x74, 0x65, 0x72, 0x54, 0x68, 0x61, 0x6e, 0x10,
-	0x07, 0x12, 0x0c, 0x0a, 0x08, 0x4c, 0x65, 0x73, 0x73, 0x54, 0x68, 0x61, 0x6e, 0x10, 0x08, 0x42,
-	0x42, 0x5a, 0x34, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x6f,
-	0x6c, 0x6f, 0x2d, 0x69, 0x6f, 0x2f, 0x73, 0x6b, 0x76, 0x32, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x61,
-	0x70, 0x69, 0x2f, 0x63, 0x6f, 0x72, 0x65, 0x2e, 0x73, 0x6b, 0x76, 0x32, 0x2e, 0x73, 0x6f, 0x6c,
-	0x6f, 0x2e, 0x69, 0x6f, 0x2f, 0x76, 0x31, 0xb8, 0xf5, 0x04, 0x01, 0xc0, 0xf5, 0x04, 0x01, 0xd0,
-	0xf5, 0x04, 0x01, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x07, 0x12, 0x0c, 0x0a, 0x08, 0x4c, 0x65, 0x73, 0x73, 0x54, 0x68, 0x61, 0x6e, 0x10, 0x08, 0x22,
+	0xd5, 0x01, 0x0a, 0x18, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x52, 0x65, 0x66, 0x57, 0x69, 0x74,
+	0x68, 0x53, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x14, 0x0a, 0x05,
+	0x67, 0x72, 0x6f, 0x75, 0x70, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x67, 0x72, 0x6f,
+	0x75, 0x70, 0x12, 0x12, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x03,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3a, 0x0a, 0x09, 0x6e, 0x61,
+	0x6d, 0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e,
+	0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e,
+	0x53, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x09, 0x6e, 0x61, 0x6d,
+	0x65, 0x73, 0x70, 0x61, 0x63, 0x65, 0x12, 0x3f, 0x0a, 0x0c, 0x73, 0x65, 0x63, 0x74, 0x69, 0x6f,
+	0x6e, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x05, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67,
+	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53,
+	0x74, 0x72, 0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x0b, 0x73, 0x65, 0x63, 0x74,
+	0x69, 0x6f, 0x6e, 0x4e, 0x61, 0x6d, 0x65, 0x42, 0x42, 0x5a, 0x34, 0x67, 0x69, 0x74, 0x68, 0x75,
+	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x6f, 0x6c, 0x6f, 0x2d, 0x69, 0x6f, 0x2f, 0x73, 0x6b,
+	0x76, 0x32, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x63, 0x6f, 0x72, 0x65, 0x2e,
+	0x73, 0x6b, 0x76, 0x32, 0x2e, 0x73, 0x6f, 0x6c, 0x6f, 0x2e, 0x69, 0x6f, 0x2f, 0x76, 0x31, 0xb8,
+	0xf5, 0x04, 0x01, 0xc0, 0xf5, 0x04, 0x01, 0xd0, 0xf5, 0x04, 0x01, 0x62, 0x06, 0x70, 0x72, 0x6f,
+	0x74, 0x6f, 0x33,
 }
 
 var (
@@ -847,7 +950,7 @@ func file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDescGZIP() []byte {
 }
 
 var file_github_com_solo_io_skv2_api_core_v1_core_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_github_com_solo_io_skv2_api_core_v1_core_proto_goTypes = []interface{}{
 	(Status_State)(0),                       // 0: core.skv2.solo.io.Status.State
 	(ObjectSelector_Expression_Operator)(0), // 1: core.skv2.solo.io.ObjectSelector.Expression.Operator
@@ -858,28 +961,31 @@ var file_github_com_solo_io_skv2_api_core_v1_core_proto_goTypes = []interface{}{
 	(*TypedClusterObjectRef)(nil),           // 6: core.skv2.solo.io.TypedClusterObjectRef
 	(*Status)(nil),                          // 7: core.skv2.solo.io.Status
 	(*ObjectSelector)(nil),                  // 8: core.skv2.solo.io.ObjectSelector
-	nil,                                     // 9: core.skv2.solo.io.ObjectSelector.LabelsEntry
-	(*ObjectSelector_Expression)(nil),       // 10: core.skv2.solo.io.ObjectSelector.Expression
-	(*wrappers.StringValue)(nil),            // 11: google.protobuf.StringValue
-	(*timestamp.Timestamp)(nil),             // 12: google.protobuf.Timestamp
+	(*TargetRefWithSectionName)(nil),        // 9: core.skv2.solo.io.TargetRefWithSectionName
+	nil,                                     // 10: core.skv2.solo.io.ObjectSelector.LabelsEntry
+	(*ObjectSelector_Expression)(nil),       // 11: core.skv2.solo.io.ObjectSelector.Expression
+	(*wrappers.StringValue)(nil),            // 12: google.protobuf.StringValue
+	(*timestamp.Timestamp)(nil),             // 13: google.protobuf.Timestamp
 }
 var file_github_com_solo_io_skv2_api_core_v1_core_proto_depIdxs = []int32{
 	2,  // 0: core.skv2.solo.io.ObjectRefList.refs:type_name -> core.skv2.solo.io.ObjectRef
-	11, // 1: core.skv2.solo.io.TypedObjectRef.api_group:type_name -> google.protobuf.StringValue
-	11, // 2: core.skv2.solo.io.TypedObjectRef.kind:type_name -> google.protobuf.StringValue
-	11, // 3: core.skv2.solo.io.TypedClusterObjectRef.api_group:type_name -> google.protobuf.StringValue
-	11, // 4: core.skv2.solo.io.TypedClusterObjectRef.kind:type_name -> google.protobuf.StringValue
+	12, // 1: core.skv2.solo.io.TypedObjectRef.api_group:type_name -> google.protobuf.StringValue
+	12, // 2: core.skv2.solo.io.TypedObjectRef.kind:type_name -> google.protobuf.StringValue
+	12, // 3: core.skv2.solo.io.TypedClusterObjectRef.api_group:type_name -> google.protobuf.StringValue
+	12, // 4: core.skv2.solo.io.TypedClusterObjectRef.kind:type_name -> google.protobuf.StringValue
 	0,  // 5: core.skv2.solo.io.Status.state:type_name -> core.skv2.solo.io.Status.State
-	12, // 6: core.skv2.solo.io.Status.processing_time:type_name -> google.protobuf.Timestamp
-	11, // 7: core.skv2.solo.io.Status.owner:type_name -> google.protobuf.StringValue
-	9,  // 8: core.skv2.solo.io.ObjectSelector.labels:type_name -> core.skv2.solo.io.ObjectSelector.LabelsEntry
-	10, // 9: core.skv2.solo.io.ObjectSelector.expressions:type_name -> core.skv2.solo.io.ObjectSelector.Expression
-	1,  // 10: core.skv2.solo.io.ObjectSelector.Expression.operator:type_name -> core.skv2.solo.io.ObjectSelector.Expression.Operator
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	13, // 6: core.skv2.solo.io.Status.processing_time:type_name -> google.protobuf.Timestamp
+	12, // 7: core.skv2.solo.io.Status.owner:type_name -> google.protobuf.StringValue
+	10, // 8: core.skv2.solo.io.ObjectSelector.labels:type_name -> core.skv2.solo.io.ObjectSelector.LabelsEntry
+	11, // 9: core.skv2.solo.io.ObjectSelector.expressions:type_name -> core.skv2.solo.io.ObjectSelector.Expression
+	12, // 10: core.skv2.solo.io.TargetRefWithSectionName.namespace:type_name -> google.protobuf.StringValue
+	12, // 11: core.skv2.solo.io.TargetRefWithSectionName.section_name:type_name -> google.protobuf.StringValue
+	1,  // 12: core.skv2.solo.io.ObjectSelector.Expression.operator:type_name -> core.skv2.solo.io.ObjectSelector.Expression.Operator
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_github_com_solo_io_skv2_api_core_v1_core_proto_init() }
@@ -972,7 +1078,19 @@ func file_github_com_solo_io_skv2_api_core_v1_core_proto_init() {
 				return nil
 			}
 		}
-		file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+		file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TargetRefWithSectionName); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ObjectSelector_Expression); i {
 			case 0:
 				return &v.state
@@ -991,7 +1109,7 @@ func file_github_com_solo_io_skv2_api_core_v1_core_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDesc,
 			NumEnums:      2,
-			NumMessages:   9,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/api/core.skv2.solo.io/v1/core.pb.hash.go
+++ b/pkg/api/core.skv2.solo.io/v1/core.pb.hash.go
@@ -391,6 +391,74 @@ func (m *ObjectSelector) Hash(hasher hash.Hash64) (uint64, error) {
 }
 
 // Hash function
+func (m *TargetRefWithSectionName) Hash(hasher hash.Hash64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	if hasher == nil {
+		hasher = fnv.New64()
+	}
+	var err error
+	if _, err = hasher.Write([]byte("core.skv2.solo.io.github.com/solo-io/skv2/pkg/api/core.skv2.solo.io/v1.TargetRefWithSectionName")); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetGroup())); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetKind())); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetName())); err != nil {
+		return 0, err
+	}
+
+	if h, ok := interface{}(m.GetNamespace()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("Namespace")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetNamespace(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("Namespace")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	if h, ok := interface{}(m.GetSectionName()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("SectionName")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetSectionName(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("SectionName")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	return hasher.Sum64(), nil
+}
+
+// Hash function
 func (m *ObjectSelector_Expression) Hash(hasher hash.Hash64) (uint64, error) {
 	if m == nil {
 		return 0, nil


### PR DESCRIPTION
Clone the Gateway API `PolicyTargetReferenceWithSectionName` field for use within Solo-defined policies targeting Gateway API resources
BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/529