### PR TITLE
Remove extra  field so generated docs don't have duplicate  descripti…

### DIFF
--- a/changelog/v0.36.4/remove-extra-field.yaml
+++ b/changelog/v0.36.4/remove-extra-field.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/skv2/issues/532
+    description: >
+      Remove extra `enabled` field so generated docs don't have duplicate `enabled` descriptions.

--- a/codegen/model/chart.go
+++ b/codegen/model/chart.go
@@ -268,7 +268,6 @@ func (c Chart) BuildChartValues() values.UserHelmValues {
 				RunAsUser:           10101,
 				ServiceType:         operator.Service.Type,
 				ServicePorts:        servicePorts,
-				Enabled:             true,
 			},
 			CustomValues: operator.Values,
 		})

--- a/codegen/model/values/helm_chart_values.go
+++ b/codegen/model/values/helm_chart_values.go
@@ -65,8 +65,6 @@ type UserValues struct {
 	// Overrides which can be set by the user
 	DeploymentOverrides *appsv1.Deployment `json:"deploymentOverrides" desc:"Arbitrary overrides for the component's [deployment template](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/)." omitChildren:"true"`
 	ServiceOverrides    *v1.Service        `json:"serviceOverrides" desc:"Arbitrary overrides for the component's [service template](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/)." omitChildren:"true"`
-
-	Enabled bool `json:"enabled" desc:"Enable creation of the deployment/service."`
 }
 
 // document values structure for a container

--- a/codegen/render/funcs_test.go
+++ b/codegen/render/funcs_test.go
@@ -367,7 +367,6 @@ var _ = Describe("toYAMLWithComments", func() {
 		mergedNode := render.MergeNodes(render.ToNode(baseValues, config), render.ToNode(customValues, config))
 
 		fmt.Println(render.FromNode(mergedNode))
-		Expect(render.FromNode(mergedNode)).To(ContainSubstring("enabled: false"))
 		Expect(render.FromNode(mergedNode)).To(ContainSubstring("floatingUserId: true"))
 		Expect(render.FromNode(mergedNode)).To(ContainSubstring("https: 80"))
 		Expect(render.FromNode(mergedNode)).To(ContainSubstring("OTHER_VAR"))
@@ -393,7 +392,6 @@ var _ = Describe("toJSONSchema", func() {
 			Operators: []values.UserOperatorValues{
 				{
 					Name:         "operator1",
-					Values:       values.UserValues{},
 					CustomValues: &Type2{Field2a: "hello2"},
 				},
 				{
@@ -428,7 +426,6 @@ var _ = Describe("toJSONSchema", func() {
 
 		checkHasStandardValuesFields := func(valueProperties map[string]map[string]interface{}) {
 			Expect(valueProperties["image"]["type"]).To(Equal("object"))
-			Expect(valueProperties["enabled"]["type"]).To(Equal("boolean"))
 			Expect(valueProperties["runAsUser"]["type"]).To(Equal("integer"))
 		}
 

--- a/codegen/render/funcs_test.go
+++ b/codegen/render/funcs_test.go
@@ -325,7 +325,6 @@ var _ = Describe("toYAMLWithComments", func() {
 
 		baseValues := map[string]interface{}{
 			"operatorName": values.UserValues{
-				Enabled: true,
 				UserContainerValues: values.UserContainerValues{
 					Env: []v1.EnvVar{{
 						Name: "POD_NAMESPACE",
@@ -347,7 +346,6 @@ var _ = Describe("toYAMLWithComments", func() {
 
 		customValues := map[string]interface{}{
 			"operatorName": values.UserValues{
-				Enabled: false,
 				UserContainerValues: values.UserContainerValues{
 					Env: []v1.EnvVar{{
 						Name: "OTHER_VAR",

--- a/codegen/render/kube_crud_test.go
+++ b/codegen/render/kube_crud_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Generated Code", func() {
 		))
 		err := applyFile("things.test.io_crds.yaml")
 
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), "failed to apply crds")
 		ns = randutils.RandString(4)
 		kube = kubehelp.MustKubeClient()
 		err = kubeutils.CreateNamespacesInParallel(ctx, kube, ns)

--- a/codegen/test/chart-envvars/values.yaml
+++ b/codegen/test/chart-envvars/values.yaml
@@ -2,7 +2,6 @@
 
 painter:
   deploymentOverrides: null
-  enabled: true
   env: null
   extraEnvs: {}
   floatingUserId: false

--- a/codegen/test/chart-no-desc/values.yaml
+++ b/codegen/test/chart-no-desc/values.yaml
@@ -2,7 +2,6 @@
 
 painter:
   deploymentOverrides: null
-  enabled: true
   env:
     - name: FOO
       value: BAR

--- a/codegen/test/chart-readiness/values.yaml
+++ b/codegen/test/chart-readiness/values.yaml
@@ -2,7 +2,6 @@
 
 painter:
   deploymentOverrides: null
-  enabled: true
   env: null
   extraEnvs: {}
   floatingUserId: false

--- a/codegen/test/chart-sidecar-svcport/values.yaml
+++ b/codegen/test/chart-sidecar-svcport/values.yaml
@@ -2,7 +2,6 @@
 
 painter:
   deploymentOverrides: null
-  enabled: true
   env: null
   extraEnvs: {}
   floatingUserId: false

--- a/codegen/test/chart-sidecar/values.yaml
+++ b/codegen/test/chart-sidecar/values.yaml
@@ -2,7 +2,6 @@
 
 painter:
   deploymentOverrides: null
-  enabled: true
   env: null
   extraEnvs: {}
   floatingUserId: false

--- a/codegen/test/chart-svcport/values.yaml
+++ b/codegen/test/chart-svcport/values.yaml
@@ -2,7 +2,6 @@
 
 painter:
   deploymentOverrides: null
-  enabled: true
   env: null
   extraEnvs: {}
   floatingUserId: false

--- a/codegen/test/chart/conditional-sidecar/values.yaml
+++ b/codegen/test/chart/conditional-sidecar/values.yaml
@@ -2,7 +2,6 @@
 
 glooAgent:
   deploymentOverrides: null
-  enabled: true
   env: null
   extraEnvs: {}
   floatingUserId: false
@@ -14,7 +13,6 @@ glooAgent:
   sidecars: {}
 glooMgmtServer:
   deploymentOverrides: null
-  enabled: true
   env: null
   extraEnvs: {}
   floatingUserId: false

--- a/codegen/test/chart/values.schema.json
+++ b/codegen/test/chart/values.schema.json
@@ -8936,9 +8936,6 @@
             }
           ]
         },
-        "enabled": {
-          "type": "boolean"
-        },
         "customField2_renamed": {
           "type": "number"
         }

--- a/codegen/test/chart/values.yaml
+++ b/codegen/test/chart/values.yaml
@@ -2,7 +2,6 @@
 
 painter:
   deploymentOverrides: null
-  enabled: true
   env: null
   extraEnvs: {}
   floatingUserId: false

--- a/codegen/test/name_override_chart/name_override_chart_reference.md
+++ b/codegen/test/name_override_chart/name_override_chart_reference.md
@@ -10,7 +10,6 @@ weight: 2
 |overrideName|struct|| |
 |overrideName|struct|Configuration for the overrideName deployment.| |
 |overrideName.deploymentOverrides|struct|Arbitrary overrides for the component's [deployment template](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/).| |
-|overrideName.enabled|bool|Enable creation of the deployment/service.|true|
 |overrideName.env[]|slice|Environment variables for the container. For more info, see the [Kubernetes documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#envvarsource-v1-core).|null|
 |overrideName.extraEnvs|struct|Extra environment variables for the container| |
 |overrideName.floatingUserId|bool|Allow the pod to be assigned a dynamic user ID. Required for OpenShift installations.|false|

--- a/codegen/test/name_override_chart/values.yaml
+++ b/codegen/test/name_override_chart/values.yaml
@@ -4,8 +4,6 @@ overrideName:
   # Arbitrary overrides for the component's [deployment
   # template](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/deployment-v1/).
   deploymentOverrides: null
-  # Enable creation of the deployment/service.
-  enabled: true
   # Environment variables for the container. For more info, see the [Kubernetes
   # documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#envvarsource-v1-core).
   env: null


### PR DESCRIPTION
If an operator has `enabled` field defined in the provided values `skv2` will generate another line for the default `enabled` field found when building helm chart values.

E.g:
```
type glooAgent struct{
  enabled bool `desc: "enabled gloo agent component"
}
```

Prior to this change would result in the following lines existing in the generated reference doc

```
|glooAgent.enabled|bool|enabled gloo agent component|false|
|glooAgent.enabled|bool|Enable creation of the deployment/service.|true|
```

BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/532