### PR TITLE
rename TargetRefWithSectionName, add PolicyTargetReference

### DIFF
--- a/api/core/v1/core.proto
+++ b/api/core/v1/core.proto
@@ -162,14 +162,28 @@ message ObjectSelector {
     }
 }
 
-// TargetRef identifies Gateway API objects to apply a direct policy to.
+// PolicyTargetReference identifies Gateway API objects to directly apply policy to.
 // This is a copy of the upstream K8s Gateway API `targetRef` API.
-// Note that we are only using the upstream `PolicyTargetReferenceWithSectionName` type as currently our policies will distinguish between sections.
+// See the following for more information:
+// * https://gateway-api.sigs.k8s.io/geps/gep-713/
+// * https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.PolicyTargetReference
+// * https://github.com/kubernetes-sigs/gateway-api/blob/b4f0307cc9269e73187300e72979e7e111ab74ab/apis/v1alpha2/policy_types.go#L34-L56
+message PolicyTargetReference {
+  string group = 1;
+  string kind = 2;
+  string name = 3;
+
+  // Optional, if unspecified, the local namespace of the policy is inferred.
+  google.protobuf.StringValue namespace = 4;
+}
+
+// PolicyTargetReferenceWithSectionName identifies Gateway API objects, and optionally a specific section of those objects, to directly apply policy to.
+// This is a copy of the upstream K8s Gateway API `targetRef` API.
 // See the following for more information:
 // * https://gateway-api.sigs.k8s.io/geps/gep-713/
 // * https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.PolicyTargetReferenceWithSectionName
-// * https://github.com/kubernetes-sigs/gateway-api/blob/444631bfe06f3bcca5d0eadf1857eac1d369421d/apis/v1alpha2/policy_types.go#L58-L83
-message TargetRefWithSectionName {
+// * https://github.com/kubernetes-sigs/gateway-api/blob/b4f0307cc9269e73187300e72979e7e111ab74ab/apis/v1alpha2/policy_types.go#L58-L83
+message PolicyTargetReferenceWithSectionName {
   string group = 1;
   string kind = 2;
   string name = 3;

--- a/changelog/v0.36.5/add-target-ref.yaml
+++ b/changelog/v0.36.5/add-target-ref.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/skv2/issues/529
+    description: rename TargetRefWithSectionName, add PolicyTargetReference

--- a/pkg/api/core.skv2.solo.io/v1/core.pb.clone.go
+++ b/pkg/api/core.skv2.solo.io/v1/core.pb.clone.go
@@ -213,12 +213,35 @@ func (m *ObjectSelector) Clone() proto.Message {
 }
 
 // Clone function
-func (m *TargetRefWithSectionName) Clone() proto.Message {
-	var target *TargetRefWithSectionName
+func (m *PolicyTargetReference) Clone() proto.Message {
+	var target *PolicyTargetReference
 	if m == nil {
 		return target
 	}
-	target = &TargetRefWithSectionName{}
+	target = &PolicyTargetReference{}
+
+	target.Group = m.GetGroup()
+
+	target.Kind = m.GetKind()
+
+	target.Name = m.GetName()
+
+	if h, ok := interface{}(m.GetNamespace()).(clone.Cloner); ok {
+		target.Namespace = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+	} else {
+		target.Namespace = proto.Clone(m.GetNamespace()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+	}
+
+	return target
+}
+
+// Clone function
+func (m *PolicyTargetReferenceWithSectionName) Clone() proto.Message {
+	var target *PolicyTargetReferenceWithSectionName
+	if m == nil {
+		return target
+	}
+	target = &PolicyTargetReferenceWithSectionName{}
 
 	target.Group = m.GetGroup()
 

--- a/pkg/api/core.skv2.solo.io/v1/core.pb.equal.go
+++ b/pkg/api/core.skv2.solo.io/v1/core.pb.equal.go
@@ -362,14 +362,60 @@ func (m *ObjectSelector) Equal(that interface{}) bool {
 }
 
 // Equal function
-func (m *TargetRefWithSectionName) Equal(that interface{}) bool {
+func (m *PolicyTargetReference) Equal(that interface{}) bool {
 	if that == nil {
 		return m == nil
 	}
 
-	target, ok := that.(*TargetRefWithSectionName)
+	target, ok := that.(*PolicyTargetReference)
 	if !ok {
-		that2, ok := that.(TargetRefWithSectionName)
+		that2, ok := that.(PolicyTargetReference)
+		if ok {
+			target = &that2
+		} else {
+			return false
+		}
+	}
+	if target == nil {
+		return m == nil
+	} else if m == nil {
+		return false
+	}
+
+	if strings.Compare(m.GetGroup(), target.GetGroup()) != 0 {
+		return false
+	}
+
+	if strings.Compare(m.GetKind(), target.GetKind()) != 0 {
+		return false
+	}
+
+	if strings.Compare(m.GetName(), target.GetName()) != 0 {
+		return false
+	}
+
+	if h, ok := interface{}(m.GetNamespace()).(equality.Equalizer); ok {
+		if !h.Equal(target.GetNamespace()) {
+			return false
+		}
+	} else {
+		if !proto.Equal(m.GetNamespace(), target.GetNamespace()) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Equal function
+func (m *PolicyTargetReferenceWithSectionName) Equal(that interface{}) bool {
+	if that == nil {
+		return m == nil
+	}
+
+	target, ok := that.(*PolicyTargetReferenceWithSectionName)
+	if !ok {
+		that2, ok := that.(PolicyTargetReferenceWithSectionName)
 		if ok {
 			target = &that2
 		} else {

--- a/pkg/api/core.skv2.solo.io/v1/core.pb.go
+++ b/pkg/api/core.skv2.solo.io/v1/core.pb.go
@@ -654,14 +654,91 @@ func (x *ObjectSelector) GetExpressions() []*ObjectSelector_Expression {
 	return nil
 }
 
-// TargetRef identifies Gateway API objects to apply a direct policy to.
+// PolicyTargetReference identifies Gateway API objects to directly apply policy to.
 // This is a copy of the upstream K8s Gateway API `targetRef` API.
-// Note that we are only using the upstream `PolicyTargetReferenceWithSectionName` type as currently our policies will distinguish between sections.
+// See the following for more information:
+// * https://gateway-api.sigs.k8s.io/geps/gep-713/
+// * https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.PolicyTargetReference
+// * https://github.com/kubernetes-sigs/gateway-api/blob/b4f0307cc9269e73187300e72979e7e111ab74ab/apis/v1alpha2/policy_types.go#L34-L56
+type PolicyTargetReference struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Group string `protobuf:"bytes,1,opt,name=group,proto3" json:"group,omitempty"`
+	Kind  string `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Name  string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
+	// Optional, if unspecified, the local namespace of the policy is inferred.
+	Namespace *wrappers.StringValue `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
+}
+
+func (x *PolicyTargetReference) Reset() {
+	*x = PolicyTargetReference{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[7]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *PolicyTargetReference) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PolicyTargetReference) ProtoMessage() {}
+
+func (x *PolicyTargetReference) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[7]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PolicyTargetReference.ProtoReflect.Descriptor instead.
+func (*PolicyTargetReference) Descriptor() ([]byte, []int) {
+	return file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *PolicyTargetReference) GetGroup() string {
+	if x != nil {
+		return x.Group
+	}
+	return ""
+}
+
+func (x *PolicyTargetReference) GetKind() string {
+	if x != nil {
+		return x.Kind
+	}
+	return ""
+}
+
+func (x *PolicyTargetReference) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *PolicyTargetReference) GetNamespace() *wrappers.StringValue {
+	if x != nil {
+		return x.Namespace
+	}
+	return nil
+}
+
+// PolicyTargetReferenceWithSectionName identifies Gateway API objects, and optionally a specific section of those objects, to directly apply policy to.
+// This is a copy of the upstream K8s Gateway API `targetRef` API.
 // See the following for more information:
 // * https://gateway-api.sigs.k8s.io/geps/gep-713/
 // * https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.PolicyTargetReferenceWithSectionName
-// * https://github.com/kubernetes-sigs/gateway-api/blob/444631bfe06f3bcca5d0eadf1857eac1d369421d/apis/v1alpha2/policy_types.go#L58-L83
-type TargetRefWithSectionName struct {
+// * https://github.com/kubernetes-sigs/gateway-api/blob/b4f0307cc9269e73187300e72979e7e111ab74ab/apis/v1alpha2/policy_types.go#L58-L83
+type PolicyTargetReferenceWithSectionName struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
@@ -676,23 +753,23 @@ type TargetRefWithSectionName struct {
 	SectionName *wrappers.StringValue `protobuf:"bytes,5,opt,name=section_name,json=sectionName,proto3" json:"section_name,omitempty"`
 }
 
-func (x *TargetRefWithSectionName) Reset() {
-	*x = TargetRefWithSectionName{}
+func (x *PolicyTargetReferenceWithSectionName) Reset() {
+	*x = PolicyTargetReferenceWithSectionName{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[7]
+		mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[8]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
 }
 
-func (x *TargetRefWithSectionName) String() string {
+func (x *PolicyTargetReferenceWithSectionName) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*TargetRefWithSectionName) ProtoMessage() {}
+func (*PolicyTargetReferenceWithSectionName) ProtoMessage() {}
 
-func (x *TargetRefWithSectionName) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[7]
+func (x *PolicyTargetReferenceWithSectionName) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[8]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -703,40 +780,40 @@ func (x *TargetRefWithSectionName) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use TargetRefWithSectionName.ProtoReflect.Descriptor instead.
-func (*TargetRefWithSectionName) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDescGZIP(), []int{7}
+// Deprecated: Use PolicyTargetReferenceWithSectionName.ProtoReflect.Descriptor instead.
+func (*PolicyTargetReferenceWithSectionName) Descriptor() ([]byte, []int) {
+	return file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDescGZIP(), []int{8}
 }
 
-func (x *TargetRefWithSectionName) GetGroup() string {
+func (x *PolicyTargetReferenceWithSectionName) GetGroup() string {
 	if x != nil {
 		return x.Group
 	}
 	return ""
 }
 
-func (x *TargetRefWithSectionName) GetKind() string {
+func (x *PolicyTargetReferenceWithSectionName) GetKind() string {
 	if x != nil {
 		return x.Kind
 	}
 	return ""
 }
 
-func (x *TargetRefWithSectionName) GetName() string {
+func (x *PolicyTargetReferenceWithSectionName) GetName() string {
 	if x != nil {
 		return x.Name
 	}
 	return ""
 }
 
-func (x *TargetRefWithSectionName) GetNamespace() *wrappers.StringValue {
+func (x *PolicyTargetReferenceWithSectionName) GetNamespace() *wrappers.StringValue {
 	if x != nil {
 		return x.Namespace
 	}
 	return nil
 }
 
-func (x *TargetRefWithSectionName) GetSectionName() *wrappers.StringValue {
+func (x *PolicyTargetReferenceWithSectionName) GetSectionName() *wrappers.StringValue {
 	if x != nil {
 		return x.SectionName
 	}
@@ -759,7 +836,7 @@ type ObjectSelector_Expression struct {
 func (x *ObjectSelector_Expression) Reset() {
 	*x = ObjectSelector_Expression{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[9]
+		mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[10]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -772,7 +849,7 @@ func (x *ObjectSelector_Expression) String() string {
 func (*ObjectSelector_Expression) ProtoMessage() {}
 
 func (x *ObjectSelector_Expression) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[9]
+	mi := &file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[10]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -916,7 +993,17 @@ var file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDesc = []byte{
 	0x0a, 0x0c, 0x44, 0x6f, 0x65, 0x73, 0x4e, 0x6f, 0x74, 0x45, 0x78, 0x69, 0x73, 0x74, 0x10, 0x06,
 	0x12, 0x0f, 0x0a, 0x0b, 0x47, 0x72, 0x65, 0x61, 0x74, 0x65, 0x72, 0x54, 0x68, 0x61, 0x6e, 0x10,
 	0x07, 0x12, 0x0c, 0x0a, 0x08, 0x4c, 0x65, 0x73, 0x73, 0x54, 0x68, 0x61, 0x6e, 0x10, 0x08, 0x22,
-	0xd5, 0x01, 0x0a, 0x18, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74, 0x52, 0x65, 0x66, 0x57, 0x69, 0x74,
+	0x91, 0x01, 0x0a, 0x15, 0x50, 0x6f, 0x6c, 0x69, 0x63, 0x79, 0x54, 0x61, 0x72, 0x67, 0x65, 0x74,
+	0x52, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x67, 0x72, 0x6f,
+	0x75, 0x70, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x12,
+	0x12, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6b,
+	0x69, 0x6e, 0x64, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28,
+	0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x3a, 0x0a, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x73,
+	0x70, 0x61, 0x63, 0x65, 0x18, 0x04, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x6f, 0x6f,
+	0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x53, 0x74, 0x72,
+	0x69, 0x6e, 0x67, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x09, 0x6e, 0x61, 0x6d, 0x65, 0x73, 0x70,
+	0x61, 0x63, 0x65, 0x22, 0xe1, 0x01, 0x0a, 0x24, 0x50, 0x6f, 0x6c, 0x69, 0x63, 0x79, 0x54, 0x61,
+	0x72, 0x67, 0x65, 0x74, 0x52, 0x65, 0x66, 0x65, 0x72, 0x65, 0x6e, 0x63, 0x65, 0x57, 0x69, 0x74,
 	0x68, 0x53, 0x65, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x4e, 0x61, 0x6d, 0x65, 0x12, 0x14, 0x0a, 0x05,
 	0x67, 0x72, 0x6f, 0x75, 0x70, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x67, 0x72, 0x6f,
 	0x75, 0x70, 0x12, 0x12, 0x0a, 0x04, 0x6b, 0x69, 0x6e, 0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09,
@@ -950,42 +1037,44 @@ func file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDescGZIP() []byte {
 }
 
 var file_github_com_solo_io_skv2_api_core_v1_core_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
+var file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_github_com_solo_io_skv2_api_core_v1_core_proto_goTypes = []interface{}{
-	(Status_State)(0),                       // 0: core.skv2.solo.io.Status.State
-	(ObjectSelector_Expression_Operator)(0), // 1: core.skv2.solo.io.ObjectSelector.Expression.Operator
-	(*ObjectRef)(nil),                       // 2: core.skv2.solo.io.ObjectRef
-	(*ObjectRefList)(nil),                   // 3: core.skv2.solo.io.ObjectRefList
-	(*ClusterObjectRef)(nil),                // 4: core.skv2.solo.io.ClusterObjectRef
-	(*TypedObjectRef)(nil),                  // 5: core.skv2.solo.io.TypedObjectRef
-	(*TypedClusterObjectRef)(nil),           // 6: core.skv2.solo.io.TypedClusterObjectRef
-	(*Status)(nil),                          // 7: core.skv2.solo.io.Status
-	(*ObjectSelector)(nil),                  // 8: core.skv2.solo.io.ObjectSelector
-	(*TargetRefWithSectionName)(nil),        // 9: core.skv2.solo.io.TargetRefWithSectionName
-	nil,                                     // 10: core.skv2.solo.io.ObjectSelector.LabelsEntry
-	(*ObjectSelector_Expression)(nil),       // 11: core.skv2.solo.io.ObjectSelector.Expression
-	(*wrappers.StringValue)(nil),            // 12: google.protobuf.StringValue
-	(*timestamp.Timestamp)(nil),             // 13: google.protobuf.Timestamp
+	(Status_State)(0),                            // 0: core.skv2.solo.io.Status.State
+	(ObjectSelector_Expression_Operator)(0),      // 1: core.skv2.solo.io.ObjectSelector.Expression.Operator
+	(*ObjectRef)(nil),                            // 2: core.skv2.solo.io.ObjectRef
+	(*ObjectRefList)(nil),                        // 3: core.skv2.solo.io.ObjectRefList
+	(*ClusterObjectRef)(nil),                     // 4: core.skv2.solo.io.ClusterObjectRef
+	(*TypedObjectRef)(nil),                       // 5: core.skv2.solo.io.TypedObjectRef
+	(*TypedClusterObjectRef)(nil),                // 6: core.skv2.solo.io.TypedClusterObjectRef
+	(*Status)(nil),                               // 7: core.skv2.solo.io.Status
+	(*ObjectSelector)(nil),                       // 8: core.skv2.solo.io.ObjectSelector
+	(*PolicyTargetReference)(nil),                // 9: core.skv2.solo.io.PolicyTargetReference
+	(*PolicyTargetReferenceWithSectionName)(nil), // 10: core.skv2.solo.io.PolicyTargetReferenceWithSectionName
+	nil,                               // 11: core.skv2.solo.io.ObjectSelector.LabelsEntry
+	(*ObjectSelector_Expression)(nil), // 12: core.skv2.solo.io.ObjectSelector.Expression
+	(*wrappers.StringValue)(nil),      // 13: google.protobuf.StringValue
+	(*timestamp.Timestamp)(nil),       // 14: google.protobuf.Timestamp
 }
 var file_github_com_solo_io_skv2_api_core_v1_core_proto_depIdxs = []int32{
 	2,  // 0: core.skv2.solo.io.ObjectRefList.refs:type_name -> core.skv2.solo.io.ObjectRef
-	12, // 1: core.skv2.solo.io.TypedObjectRef.api_group:type_name -> google.protobuf.StringValue
-	12, // 2: core.skv2.solo.io.TypedObjectRef.kind:type_name -> google.protobuf.StringValue
-	12, // 3: core.skv2.solo.io.TypedClusterObjectRef.api_group:type_name -> google.protobuf.StringValue
-	12, // 4: core.skv2.solo.io.TypedClusterObjectRef.kind:type_name -> google.protobuf.StringValue
+	13, // 1: core.skv2.solo.io.TypedObjectRef.api_group:type_name -> google.protobuf.StringValue
+	13, // 2: core.skv2.solo.io.TypedObjectRef.kind:type_name -> google.protobuf.StringValue
+	13, // 3: core.skv2.solo.io.TypedClusterObjectRef.api_group:type_name -> google.protobuf.StringValue
+	13, // 4: core.skv2.solo.io.TypedClusterObjectRef.kind:type_name -> google.protobuf.StringValue
 	0,  // 5: core.skv2.solo.io.Status.state:type_name -> core.skv2.solo.io.Status.State
-	13, // 6: core.skv2.solo.io.Status.processing_time:type_name -> google.protobuf.Timestamp
-	12, // 7: core.skv2.solo.io.Status.owner:type_name -> google.protobuf.StringValue
-	10, // 8: core.skv2.solo.io.ObjectSelector.labels:type_name -> core.skv2.solo.io.ObjectSelector.LabelsEntry
-	11, // 9: core.skv2.solo.io.ObjectSelector.expressions:type_name -> core.skv2.solo.io.ObjectSelector.Expression
-	12, // 10: core.skv2.solo.io.TargetRefWithSectionName.namespace:type_name -> google.protobuf.StringValue
-	12, // 11: core.skv2.solo.io.TargetRefWithSectionName.section_name:type_name -> google.protobuf.StringValue
-	1,  // 12: core.skv2.solo.io.ObjectSelector.Expression.operator:type_name -> core.skv2.solo.io.ObjectSelector.Expression.Operator
-	13, // [13:13] is the sub-list for method output_type
-	13, // [13:13] is the sub-list for method input_type
-	13, // [13:13] is the sub-list for extension type_name
-	13, // [13:13] is the sub-list for extension extendee
-	0,  // [0:13] is the sub-list for field type_name
+	14, // 6: core.skv2.solo.io.Status.processing_time:type_name -> google.protobuf.Timestamp
+	13, // 7: core.skv2.solo.io.Status.owner:type_name -> google.protobuf.StringValue
+	11, // 8: core.skv2.solo.io.ObjectSelector.labels:type_name -> core.skv2.solo.io.ObjectSelector.LabelsEntry
+	12, // 9: core.skv2.solo.io.ObjectSelector.expressions:type_name -> core.skv2.solo.io.ObjectSelector.Expression
+	13, // 10: core.skv2.solo.io.PolicyTargetReference.namespace:type_name -> google.protobuf.StringValue
+	13, // 11: core.skv2.solo.io.PolicyTargetReferenceWithSectionName.namespace:type_name -> google.protobuf.StringValue
+	13, // 12: core.skv2.solo.io.PolicyTargetReferenceWithSectionName.section_name:type_name -> google.protobuf.StringValue
+	1,  // 13: core.skv2.solo.io.ObjectSelector.Expression.operator:type_name -> core.skv2.solo.io.ObjectSelector.Expression.Operator
+	14, // [14:14] is the sub-list for method output_type
+	14, // [14:14] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_github_com_solo_io_skv2_api_core_v1_core_proto_init() }
@@ -1079,7 +1168,7 @@ func file_github_com_solo_io_skv2_api_core_v1_core_proto_init() {
 			}
 		}
 		file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*TargetRefWithSectionName); i {
+			switch v := v.(*PolicyTargetReference); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1090,7 +1179,19 @@ func file_github_com_solo_io_skv2_api_core_v1_core_proto_init() {
 				return nil
 			}
 		}
-		file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+		file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*PolicyTargetReferenceWithSectionName); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_github_com_solo_io_skv2_api_core_v1_core_proto_msgTypes[10].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*ObjectSelector_Expression); i {
 			case 0:
 				return &v.state
@@ -1109,7 +1210,7 @@ func file_github_com_solo_io_skv2_api_core_v1_core_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDesc,
 			NumEnums:      2,
-			NumMessages:   10,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/api/core.skv2.solo.io/v1/core.pb.hash.go
+++ b/pkg/api/core.skv2.solo.io/v1/core.pb.hash.go
@@ -391,7 +391,7 @@ func (m *ObjectSelector) Hash(hasher hash.Hash64) (uint64, error) {
 }
 
 // Hash function
-func (m *TargetRefWithSectionName) Hash(hasher hash.Hash64) (uint64, error) {
+func (m *PolicyTargetReference) Hash(hasher hash.Hash64) (uint64, error) {
 	if m == nil {
 		return 0, nil
 	}
@@ -399,7 +399,55 @@ func (m *TargetRefWithSectionName) Hash(hasher hash.Hash64) (uint64, error) {
 		hasher = fnv.New64()
 	}
 	var err error
-	if _, err = hasher.Write([]byte("core.skv2.solo.io.github.com/solo-io/skv2/pkg/api/core.skv2.solo.io/v1.TargetRefWithSectionName")); err != nil {
+	if _, err = hasher.Write([]byte("core.skv2.solo.io.github.com/solo-io/skv2/pkg/api/core.skv2.solo.io/v1.PolicyTargetReference")); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetGroup())); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetKind())); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetName())); err != nil {
+		return 0, err
+	}
+
+	if h, ok := interface{}(m.GetNamespace()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("Namespace")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetNamespace(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("Namespace")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	return hasher.Sum64(), nil
+}
+
+// Hash function
+func (m *PolicyTargetReferenceWithSectionName) Hash(hasher hash.Hash64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	if hasher == nil {
+		hasher = fnv.New64()
+	}
+	var err error
+	if _, err = hasher.Write([]byte("core.skv2.solo.io.github.com/solo-io/skv2/pkg/api/core.skv2.solo.io/v1.PolicyTargetReferenceWithSectionName")); err != nil {
 		return 0, err
 	}
 


### PR DESCRIPTION
renaming message field but not used in the most recent LTS releases:
https://github.com/solo-io/gloo-mesh-enterprise/blob/v2.5.x/go.mod#L95
https://github.com/solo-io/gloo/blob/v1.16.x/go.mod#L56
BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/529