### PR TITLE
update protoc-gen-openapi to v0.2.1

### DIFF
--- a/changelog/v0.37.1/update-protoc-gen-openapi.yaml
+++ b/changelog/v0.37.1/update-protoc-gen-openapi.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/skv2/issues/541
+    resolvesIssue: true
+    description: >
+      Updates protoc-gen-openapi to v0.2.1.

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/solo-io/go-utils v0.21.4
 	github.com/solo-io/k8s-utils v0.0.1
 	github.com/solo-io/protoc-gen-ext v0.0.18
-	github.com/solo-io/protoc-gen-openapi v0.2.0
+	github.com/solo-io/protoc-gen-openapi v0.2.1
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.25.0
 	golang.org/x/exp v0.0.0-20220921164117-439092de6870

--- a/go.sum
+++ b/go.sum
@@ -818,8 +818,8 @@ github.com/solo-io/k8s-utils v0.0.1 h1:e2alFsqTT7GU10d6cFDX2y+86J142DrsRwy5itvvZ
 github.com/solo-io/k8s-utils v0.0.1/go.mod h1:53N9+9Gl2MwqIZJ7/ocA9gKvWt+6z7MPD2qKQix7oFE=
 github.com/solo-io/protoc-gen-ext v0.0.18 h1:zSAL8NzWpJUGYoA5IyjHiKASNyHjR0uxBQ7eQS94i3A=
 github.com/solo-io/protoc-gen-ext v0.0.18/go.mod h1:iGyCvmKmhJNXs5MgBcYFBF0om7LDnCVD2WwhOZGnqeA=
-github.com/solo-io/protoc-gen-openapi v0.2.0 h1:bT3Fg9JACXjxtaF646z5DSrOOnOexTwmXh5vnMAJgvc=
-github.com/solo-io/protoc-gen-openapi v0.2.0/go.mod h1:osEjRl1miHqlq4Wl/8SEqHFoyydptPL1EzEdM9c4vfE=
+github.com/solo-io/protoc-gen-openapi v0.2.1 h1:w08DzOam8ATBPCGunMF2CMV752HFIMj/AYQzqthCKKM=
+github.com/solo-io/protoc-gen-openapi v0.2.1/go.mod h1:osEjRl1miHqlq4Wl/8SEqHFoyydptPL1EzEdM9c4vfE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=


### PR DESCRIPTION
v.0.2.1 contains a bug fix for proto oneof fields.

BOT NOTES: 
resolves https://github.com/solo-io/skv2/issues/541