### PR TITLE
Add godeltapprof to debug pprof endpoints

### DIFF
--- a/changelog/v0.38.3/add-godeltapprof.yaml
+++ b/changelog/v0.38.3/add-godeltapprof.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      "adds godeltapprof to the debug endpoints, to be used with pyroscope or grafana cloud profiler"
+    skipCI: "false"

--- a/ci/oss_compliance/osa_provided.md
+++ b/ci/oss_compliance/osa_provided.md
@@ -17,8 +17,10 @@ Name|Version|License
 [cmp/internal](https://github.com/google/go-cmp)|v0.6.0|BSD 3-clause "New" or "Revised" License
 [gofuzz/bytesource](https://github.com/google/gofuzz)|v1.2.0|Apache License 2.0
 [google/uuid](https://github.com/google/uuid)|v1.3.0|BSD 3-clause "New" or "Revised" License
+[pyroscope-go/godeltaprof](https://github.com/grafana/pyroscope-go)|v0.1.6|Apache License 2.0
 [josharian/intern](https://github.com/josharian/intern)|v1.0.0|MIT License
 [json-iterator/go](https://github.com/json-iterator/go)|v1.1.12|MIT License
+[klauspost/compress](https://github.com/klauspost/compress)|v1.17.3|Apache License 2.0
 [mailru/easyjson](https://github.com/mailru/easyjson)|v0.7.7|MIT License
 [golang_protobuf_extensions/pbutil](https://github.com/matttproud/golang_protobuf_extensions)|v1.0.4|Apache License 2.0
 [modern-go/concurrent](https://github.com/modern-go/concurrent)|v0.0.0-20180306012644-bacd9c7ef1dd|Apache License 2.0

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/golang/protobuf v1.5.3
 	github.com/google/gnostic-models v0.6.8
 	github.com/google/go-cmp v0.6.0
+	github.com/grafana/pyroscope-go/godeltaprof v0.1.6
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/iancoleman/orderedmap v0.0.0-20190318233801-ac98e3ecb4b0
 	github.com/iancoleman/strcase v0.2.0
@@ -89,8 +90,6 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd // indirect
 	github.com/google/uuid v1.3.0 // indirect
-	github.com/grafana/pyroscope-go v1.1.1 // indirect
-	github.com/grafana/pyroscope-go/godeltaprof v0.1.6 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,8 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd // indirect
 	github.com/google/uuid v1.3.0 // indirect
+	github.com/grafana/pyroscope-go v1.1.1 // indirect
+	github.com/grafana/pyroscope-go/godeltaprof v0.1.6 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
@@ -98,6 +100,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/k0kubun/pp v2.3.0+incompatible // indirect
+	github.com/klauspost/compress v1.17.3 // indirect
 	github.com/lyft/protoc-gen-star v0.6.1 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -469,8 +469,6 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
-github.com/grafana/pyroscope-go v1.1.1 h1:PQoUU9oWtO3ve/fgIiklYuGilvsm8qaGhlY4Vw6MAcQ=
-github.com/grafana/pyroscope-go v1.1.1/go.mod h1:Mw26jU7jsL/KStNSGGuuVYdUq7Qghem5P8aXYXSXG88=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.6 h1:nEdZ8louGAplSvIJi1HVp7kWvFvdiiYg3COLlTwJiFo=
 github.com/grafana/pyroscope-go/godeltaprof v0.1.6/go.mod h1:Tk376Nbldo4Cha9RgiU7ik8WKFkNpfds98aUzS8omLE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/go.sum
+++ b/go.sum
@@ -469,6 +469,10 @@ github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gosuri/uitable v0.0.4/go.mod h1:tKR86bXuXPZazfOTG1FIzvjIdXzd0mo4Vtn16vt0PJo=
+github.com/grafana/pyroscope-go v1.1.1 h1:PQoUU9oWtO3ve/fgIiklYuGilvsm8qaGhlY4Vw6MAcQ=
+github.com/grafana/pyroscope-go v1.1.1/go.mod h1:Mw26jU7jsL/KStNSGGuuVYdUq7Qghem5P8aXYXSXG88=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.6 h1:nEdZ8louGAplSvIJi1HVp7kWvFvdiiYg3COLlTwJiFo=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.6/go.mod h1:Tk376Nbldo4Cha9RgiU7ik8WKFkNpfds98aUzS8omLE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
@@ -565,6 +569,8 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.17.3 h1:qkRjuerhUU1EmXLYGkSH6EZL+vPSxIrYjLNAK4slzwA=
+github.com/klauspost/compress v1.17.3/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/pkg/stats/pprof.go
+++ b/pkg/stats/pprof.go
@@ -3,6 +3,7 @@ package stats
 import (
 	"net/http"
 	"net/http/pprof"
+
 	deltapprof "github.com/grafana/pyroscope-go/godeltaprof/http/pprof"
 )
 
@@ -15,7 +16,6 @@ func AddPprof(mux *http.ServeMux) {
 	mux.HandleFunc("/debug/pprof/delta_heap", deltapprof.Heap)
 	mux.HandleFunc("/debug/pprof/delta_threadcreate", deltapprof.Mutex)
 	mux.HandleFunc("/debug/pprof/delta_block", deltapprof.Block)
-
 
 	profileDescriptions["/debug/pprof/"] = `PProf related things:<br/>
 	<a href="/debug/pprof/goroutine?debug=2">full goroutine stack dump</a>

--- a/pkg/stats/pprof.go
+++ b/pkg/stats/pprof.go
@@ -3,6 +3,7 @@ package stats
 import (
 	"net/http"
 	"net/http/pprof"
+	deltapprof "github.com/grafana/pyroscope-go/godeltaprof/http/pprof"
 )
 
 func AddPprof(mux *http.ServeMux) {
@@ -11,6 +12,10 @@ func AddPprof(mux *http.ServeMux) {
 	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	mux.HandleFunc("/debug/pprof/delta_heap", deltapprof.Heap)
+	mux.HandleFunc("/debug/pprof/delta_threadcreate", deltapprof.Mutex)
+	mux.HandleFunc("/debug/pprof/delta_block", deltapprof.Block)
+
 
 	profileDescriptions["/debug/pprof/"] = `PProf related things:<br/>
 	<a href="/debug/pprof/goroutine?debug=2">full goroutine stack dump</a>


### PR DESCRIPTION
https://github.com/grafana/pyroscope-go/tree/main/godeltaprof is used for more efficient profiling. Using this library generates delta profs as opposed to SOTW profs, which uses up less resources, for a more accurate profile of the running application.

I add godeltaprof endpoints here to complement the existing pprof endpoints. Clients like Grafana cloud profiles and pyroscope ([documentation](https://grafana.com/docs/pyroscope/latest/configure-client/grafana-agent/go_pull/)) can leverage these delta profs to generate fully detailed profiles.