### PR TITLE
shallow copy on sets

### DIFF
--- a/changelog/v0.38.4/sets-shallowcopy.yaml
+++ b/changelog/v0.38.4/sets-shallowcopy.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: 
+    description: >
+      ""
+    skipCI: "false"

--- a/contrib/pkg/sets/v2/sets.go
+++ b/contrib/pkg/sets/v2/sets.go
@@ -67,6 +67,8 @@ type ResourceSet[T client.Object] interface {
 	Generic() sk_sets.ResourceSet
 	// Clone returns a deep copy of the set
 	Clone() ResourceSet[T]
+	// ShallowCopy returns a shallow copy of the set
+	ShallowCopy() ResourceSet[T]
 }
 
 // ResourceDelta represents the set of changes between two ResourceSets.
@@ -333,6 +335,14 @@ func (oldSet *resourceSet[T]) Clone() ResourceSet[T] {
 		return true
 	})
 	return new
+}
+
+func (oldSet *resourceSet[T]) ShallowCopy() ResourceSet[T] {
+	newSet := make([]T, len(oldSet.set))
+	copy(newSet, oldSet.set)
+	return &resourceSet[T]{
+		set: newSet,
+	}
 }
 
 func (s *resourceSet[T]) Generic() sk_sets.ResourceSet {

--- a/contrib/tests/set_v2_test.go
+++ b/contrib/tests/set_v2_test.go
@@ -123,7 +123,9 @@ var _ = Describe("PaintSetV2", func() {
 		np := setA.Get(newPaint)
 		np.Name = "newPaintWithNewName"
 		Expect(setB.Len()).To(Equal(4))
-		Expect(setB.Get(newPaint).Name).To(Equal("newPaintWithNewName"))
+		npShouldBeExactSame := setB.Get(newPaint)
+		Expect(npShouldBeExactSame.Name).To(Equal("newPaintWithNewName"))
+		Expect(npShouldBeExactSame == np).To(BeTrue())
 	})
 
 	It("should double filter List", func() {

--- a/contrib/tests/set_v2_test.go
+++ b/contrib/tests/set_v2_test.go
@@ -1,8 +1,6 @@
 package tests_test
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/solo-io/skv2/codegen/test/api/things.test.io/v1"

--- a/contrib/tests/set_v2_test.go
+++ b/contrib/tests/set_v2_test.go
@@ -1,6 +1,8 @@
 package tests_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/solo-io/skv2/codegen/test/api/things.test.io/v1"
@@ -120,8 +122,8 @@ var _ = Describe("PaintSetV2", func() {
 
 		setB = setA.ShallowCopy()
 		Expect(setB.Has(newPaint)).To(BeTrue())
-		// so sorry for this n^2 comparison,
-		// want to make sure that the pointers are the same in both sets but have no better way to do it
+		// want to make sure that the pointers are the same in both sets
+		// without having to construct a new list, so we just iterate
 		setB.Iter(func(i int, p *v1.Paint) bool {
 			setA.Iter(func(j int, p2 *v1.Paint) bool {
 				if i == j {
@@ -129,13 +131,8 @@ var _ = Describe("PaintSetV2", func() {
 				}
 				return true
 			})
+			return true
 		})
-		// np := setA.Get(newPaint)
-		// np.Name = "newPaintWithNewName"
-		// Expect(setB.Len()).To(Equal(4))
-		// npShouldBeExactSame := setB.Get(newPaint)
-		// Expect(npShouldBeExactSame.Name).To(Equal("newPaintWithNewName"))
-		// Expect(npShouldBeExactSame == np).To(BeTrue())
 	})
 
 	It("should double filter List", func() {

--- a/contrib/tests/set_v2_test.go
+++ b/contrib/tests/set_v2_test.go
@@ -110,6 +110,22 @@ var _ = Describe("PaintSetV2", func() {
 		})
 	})
 
+	It("should shallow copy", func() {
+		newPaint := &v1.Paint{
+			ObjectMeta: metav1.ObjectMeta{Name: "newPaint", Namespace: "newPaint"},
+		}
+		setA.Insert(paintA, paintBCluster2, paintC, newPaint)
+		Expect(setA.Has(newPaint)).To(BeTrue())
+		Expect(setA.Len()).To(Equal(4))
+
+		setB = setA.ShallowCopy()
+		Expect(setB.Has(newPaint)).To(BeTrue())
+		np := setA.Get(newPaint)
+		np.Name = "newPaintWithNewName"
+		Expect(setB.Len()).To(Equal(4))
+		Expect(setB.Get(newPaint).Name).To(Equal("newPaintWithNewName"))
+	})
+
 	It("should double filter List", func() {
 		setA.Insert(paintA, paintBCluster2, paintC)
 		Expect(setA.Has(paintA)).To(BeTrue())

--- a/contrib/tests/set_v2_test.go
+++ b/contrib/tests/set_v2_test.go
@@ -120,12 +120,22 @@ var _ = Describe("PaintSetV2", func() {
 
 		setB = setA.ShallowCopy()
 		Expect(setB.Has(newPaint)).To(BeTrue())
-		np := setA.Get(newPaint)
-		np.Name = "newPaintWithNewName"
-		Expect(setB.Len()).To(Equal(4))
-		npShouldBeExactSame := setB.Get(newPaint)
-		Expect(npShouldBeExactSame.Name).To(Equal("newPaintWithNewName"))
-		Expect(npShouldBeExactSame == np).To(BeTrue())
+		// so sorry for this n^2 comparison,
+		// want to make sure that the pointers are the same in both sets but have no better way to do it
+		setB.Iter(func(i int, p *v1.Paint) bool {
+			setA.Iter(func(j int, p2 *v1.Paint) bool {
+				if i == j {
+					Expect(p == p2).To(BeTrue())
+				}
+				return true
+			})
+		})
+		// np := setA.Get(newPaint)
+		// np.Name = "newPaintWithNewName"
+		// Expect(setB.Len()).To(Equal(4))
+		// npShouldBeExactSame := setB.Get(newPaint)
+		// Expect(npShouldBeExactSame.Name).To(Equal("newPaintWithNewName"))
+		// Expect(npShouldBeExactSame == np).To(BeTrue())
 	})
 
 	It("should double filter List", func() {


### PR DESCRIPTION
# Description

Introduces `ShallowCopy` to v2 sets, which allows for a more efficient way to clone sets without deep copies.

This change was suggested by @EItanya  in [this comment](https://github.com/solo-io/gloo-mesh-enterprise/pull/16061#discussion_r1569088114)