### PR TITLE
codegen: fix to prevent null strategy

### DIFF
--- a/changelog/v0.38.6/fix-conditional-strategy.yaml
+++ b/changelog/v0.38.6/fix-conditional-strategy.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/15710
+    resolvesIssue: false
+    description: |
+      Avoid setting deployment strategy to null when no condition is evaluated.
+    skipCI: false

--- a/codegen/templates/chart/operator-deployment.yamltmpl
+++ b/codegen/templates/chart/operator-deployment.yamltmpl
@@ -65,9 +65,9 @@ spec:
   strategy:
 [[ toYaml $strategy | indent 4 ]]
 [[- else if $conditionalStrategy ]]
-  strategy:
 [[- range $s := $conditionalStrategy ]]
 {{- if [[ $s.Condition ]] }}
+  strategy:
 [[ toYaml $s.Strategy | indent 4 ]]
 {{- end }}
 [[- end ]]

--- a/codegen/test/chart-conditional-deployment-strategy/templates/deployment.yaml
+++ b/codegen/test/chart-conditional-deployment-strategy/templates/deployment.yaml
@@ -21,11 +21,12 @@ spec:
   selector:
     matchLabels:
       app: painter
-  strategy:
 {{- if $.Values.painter.condition }}
+  strategy:
     type: RollingUpdate
 {{- end }}
 {{- if not $.Values.painter.condition }}
+  strategy:
     type: Recreate
 {{- end }}
   template:


### PR DESCRIPTION
Prevents the deployment strategy from being null if no condition is met:

```yaml
strategy: null
```

For example, see `test/helm/snapshots/mgmt-server-redis-1-iothreads/gloo-platform-manifest.yaml` changed file in https://github.com/solo-io/gloo-mesh-enterprise/pull/16106/files