### PR TITLE
Add option to disable kubebuilder markers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export PATH:=$(GOBIN):$(PATH)
 install-go-tools: mod-download
 	mkdir -p $(DEPSGOBIN)
 	go install github.com/golang/protobuf/protoc-gen-go@v1.5.2
-	go install github.com/solo-io/protoc-gen-openapi@v0.2.0
+	go install github.com/solo-io/protoc-gen-openapi@v0.2.4
 	go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc
 	go install github.com/solo-io/protoc-gen-ext@v0.0.18
 	go install github.com/golang/mock/mockgen@v1.4.4

--- a/changelog/v0.40.2/disable-kube-markers.yaml
+++ b/changelog/v0.40.2/disable-kube-markers.yaml
@@ -5,7 +5,7 @@ changelog:
     description: |
       Adds support for disabling kubebuilder markers and validations to omit them from the generated OpenAPI schema.
   - type: DEPENDENCY_BUMP
-    description: Updates protoc-gen-openapi to v0.2.4 to pick up the disable_kube_markers option.
+    description: Updates protoc-gen-openapi to v0.2.4, though this is not explicitly necessary to pick up the disable_kube_markers option.
     dependencyOwner: solo-io
     dependencyRepo: protoc-gen-openapi
     dependencyTag: v0.2.4

--- a/changelog/v0.40.2/disable-kube-markers.yaml
+++ b/changelog/v0.40.2/disable-kube-markers.yaml
@@ -1,0 +1,11 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/17005
+    resolvesIssue: false
+    description: |
+      Adds support for disabling kubebuilder markers and validations to omit them from the generated OpenAPI schema.
+  - type: DEPENDENCY_BUMP
+    description: Updates protoc-gen-openapi to v0.2.4 to pick up the disable_kube_markers option.
+    dependencyOwner: solo-io
+    dependencyRepo: protoc-gen-openapi
+    dependencyTag: v0.2.4

--- a/codegen/collector/executor.go
+++ b/codegen/collector/executor.go
@@ -79,6 +79,10 @@ type OpenApiProtocExecutor struct {
 	// A list of messages (core.solo.io.Status) whose validation schema should
 	// not be generated
 	MessagesWithEmptySchema []string
+
+	// Whether to exclude kubebuilder markers and validations (such as PreserveUnknownFields, MinItems, default, and all CEL rules)
+	// Type and Required markers will be included regardless
+	DisableKubeMarkers bool
 }
 
 func (o *OpenApiProtocExecutor) Execute(protoFile string, toFile string, imports []string) error {
@@ -105,9 +109,10 @@ func (o *OpenApiProtocExecutor) Execute(protoFile string, toFile string, imports
 	_ = os.Mkdir(directoryPath, os.ModePerm)
 
 	cmd.Args = append(cmd.Args,
-		fmt.Sprintf("--openapi_out=yaml=true,single_file=false,include_description=true,multiline_description=true,enum_as_int_or_string=%v,proto_oneof=true,int_native=true,additional_empty_schema=%v:%s",
+		fmt.Sprintf("--openapi_out=yaml=true,single_file=false,include_description=true,multiline_description=true,enum_as_int_or_string=%v,proto_oneof=true,int_native=true,additional_empty_schema=%v,disable_kube_markers=%v:%s",
 			o.EnumAsIntOrString,
 			strings.Join(o.MessagesWithEmptySchema, "+"),
+			o.DisableKubeMarkers,
 			directoryPath),
 	)
 

--- a/codegen/proto/schemagen/generator.go
+++ b/codegen/proto/schemagen/generator.go
@@ -17,6 +17,11 @@ type ValidationSchemaOptions struct {
 	// A list of messages (e.g. ratelimit.api.solo.io.Descriptor) whose validation schema should
 	// not be generated
 	MessagesWithEmptySchema []string
+
+	// Whether to exclude kubebuilder markers and validations (such as PreserveUnknownFields, MinItems, default, and all CEL rules)
+	// Type and Required markers will be included regardless
+	// Default: false
+	DisableKubeMarkers bool
 }
 
 // prevent k8s from validating proto.Any fields (since it's unstructured)

--- a/codegen/proto/schemagen/protoc.go
+++ b/codegen/proto/schemagen/protoc.go
@@ -43,6 +43,7 @@ func (p *protocGenerator) GetJSONSchemas(protoFiles []string, imports []string, 
 		OutputDir:               tmpOutputDir,
 		EnumAsIntOrString:       p.validationSchemaOptions.EnumAsIntOrString,
 		MessagesWithEmptySchema: p.validationSchemaOptions.MessagesWithEmptySchema,
+		DisableKubeMarkers:      p.validationSchemaOptions.DisableKubeMarkers,
 	}
 
 	// 1. Generate the openApiSchemas for the project, writing them to a temp directory (schemaOutputDir)

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/solo-io/go-utils v0.21.4
 	github.com/solo-io/k8s-utils v0.0.1
 	github.com/solo-io/protoc-gen-ext v0.0.18
-	github.com/solo-io/protoc-gen-openapi v0.2.1
+	github.com/solo-io/protoc-gen-openapi v0.2.4
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20220921164117-439092de6870

--- a/go.sum
+++ b/go.sum
@@ -816,8 +816,8 @@ github.com/solo-io/k8s-utils v0.0.1 h1:e2alFsqTT7GU10d6cFDX2y+86J142DrsRwy5itvvZ
 github.com/solo-io/k8s-utils v0.0.1/go.mod h1:53N9+9Gl2MwqIZJ7/ocA9gKvWt+6z7MPD2qKQix7oFE=
 github.com/solo-io/protoc-gen-ext v0.0.18 h1:zSAL8NzWpJUGYoA5IyjHiKASNyHjR0uxBQ7eQS94i3A=
 github.com/solo-io/protoc-gen-ext v0.0.18/go.mod h1:iGyCvmKmhJNXs5MgBcYFBF0om7LDnCVD2WwhOZGnqeA=
-github.com/solo-io/protoc-gen-openapi v0.2.1 h1:w08DzOam8ATBPCGunMF2CMV752HFIMj/AYQzqthCKKM=
-github.com/solo-io/protoc-gen-openapi v0.2.1/go.mod h1:osEjRl1miHqlq4Wl/8SEqHFoyydptPL1EzEdM9c4vfE=
+github.com/solo-io/protoc-gen-openapi v0.2.4 h1:9tqGhCAq83IRSzHhKDzpWnPlbPPORTM2izVxjLk0Ftw=
+github.com/solo-io/protoc-gen-openapi v0.2.4/go.mod h1:osEjRl1miHqlq4Wl/8SEqHFoyydptPL1EzEdM9c4vfE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=


### PR DESCRIPTION
# Description

Adds option to disable kubebuilder markers and validations to omit them from the generated OpenAPI schema

# Context

This is needed for https://github.com/solo-io/gloo-mesh-enterprise/issues/17005

When disableKubeMarkers is set to true, `Type=object` annotations will be respected such that recursive fields will still work. `Required` annotations will also be respected.
