### PR TITLE
Add option to edit fullPackageName for hashing in protoc-gen-ext

### DIFF
--- a/changelog/v0.40.3/replace-package-name-for-hashing.yaml
+++ b/changelog/v0.40.3/replace-package-name-for-hashing.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo-mesh-enterprise/issues/17070
+    resolvesIssue: false
+    description: >
+      Add option to find and replace portion of the package name of a proto as it is used in the hash function.
+      It is used to provide an option for users to maintain the hashing logic when the package name of a proto changes.

--- a/codegen/collector/compiler.go
+++ b/codegen/collector/compiler.go
@@ -56,6 +56,10 @@ type ProtocOptions struct {
 
 	// Extra flags to provide to invocations of protoc
 	ProtocExtraFlags []string
+
+	// When set, it will replace the value before the "=" with the value after it in the hash function of the generated code.
+	// This is use to maintain backward compatibility of the hash function in the case where the package name changes.
+	TransformPackageForHash string
 }
 
 type protoCompiler struct {
@@ -198,9 +202,13 @@ func (p *protoCompiler) writeDescriptors(protoFile, toFile string, imports []str
 	gogoArgs := append(defaultGogoArgs, p.customArgs...)
 
 	if compileProtos {
+		extArgs := gogoArgs
+		if p.protocOptions.TransformPackageForHash != "" {
+			extArgs = append(extArgs, fmt.Sprintf("transform_package_for_hash=%s", p.protocOptions.TransformPackageForHash))
+		}
 		cmd.Args = append(cmd.Args,
 			"--go_out="+strings.Join(gogoArgs, ",")+":"+p.descriptorOutDir,
-			"--ext_out="+strings.Join(gogoArgs, ",")+":"+p.descriptorOutDir,
+			"--ext_out="+strings.Join(extArgs, ",")+":"+p.descriptorOutDir,
 		)
 
 		// Externally specify mappings between proto files and generated Go code, for proto source files that do not specify `go_package`

--- a/codegen/test/api/things.test.io/v1/test_api.pb.go
+++ b/codegen/test/api/things.test.io/v1/test_api.pb.go
@@ -10,12 +10,12 @@ import (
 	reflect "reflect"
 	sync "sync"
 
-	any1 "github.com/golang/protobuf/ptypes/any"
-	_struct "github.com/golang/protobuf/ptypes/struct"
-	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	_ "github.com/solo-io/cue/encoding/protobuf/cue"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	anypb "google.golang.org/protobuf/types/known/anypb"
+	structpb "google.golang.org/protobuf/types/known/structpb"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
@@ -85,7 +85,7 @@ type PaintSpec struct {
 	//	*PaintSpec_Acrylic
 	//	*PaintSpec_Oil
 	PaintType  isPaintSpec_PaintType `protobuf_oneof:"paintType"`
-	MyFavorite *any1.Any             `protobuf:"bytes,4,opt,name=my_favorite,json=myFavorite,proto3" json:"my_favorite,omitempty"`
+	MyFavorite *anypb.Any            `protobuf:"bytes,4,opt,name=my_favorite,json=myFavorite,proto3" json:"my_favorite,omitempty"`
 	// OpenAPI gen test for recursive fields
 	RecursiveType *PaintSpec_RecursiveType `protobuf:"bytes,5,opt,name=recursive_type,json=recursiveType,proto3" json:"recursive_type,omitempty"`
 }
@@ -150,7 +150,7 @@ func (x *PaintSpec) GetOil() *OilType {
 	return nil
 }
 
-func (x *PaintSpec) GetMyFavorite() *any1.Any {
+func (x *PaintSpec) GetMyFavorite() *anypb.Any {
 	if x != nil {
 		return x.MyFavorite
 	}
@@ -439,7 +439,7 @@ type ClusterResourceSpec struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Imported *wrappers.StringValue `protobuf:"bytes,1,opt,name=imported,proto3" json:"imported,omitempty"`
+	Imported *wrapperspb.StringValue `protobuf:"bytes,1,opt,name=imported,proto3" json:"imported,omitempty"`
 }
 
 func (x *ClusterResourceSpec) Reset() {
@@ -474,7 +474,7 @@ func (*ClusterResourceSpec) Descriptor() ([]byte, []int) {
 	return file_github_com_solo_io_skv2_codegen_test_test_api_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *ClusterResourceSpec) GetImported() *wrappers.StringValue {
+func (x *ClusterResourceSpec) GetImported() *wrapperspb.StringValue {
 	if x != nil {
 		return x.Imported
 	}
@@ -487,7 +487,7 @@ type PaintSpec_RecursiveType struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	ProtobufValue          *_struct.Value             `protobuf:"bytes,4,opt,name=protobuf_value,json=protobufValue,proto3" json:"protobuf_value,omitempty"`
+	ProtobufValue          *structpb.Value            `protobuf:"bytes,4,opt,name=protobuf_value,json=protobufValue,proto3" json:"protobuf_value,omitempty"`
 	RecursiveField         *PaintSpec_RecursiveType   `protobuf:"bytes,1,opt,name=recursive_field,json=recursiveField,proto3" json:"recursive_field,omitempty"`
 	RepeatedRecursiveField []*PaintSpec_RecursiveType `protobuf:"bytes,2,rep,name=repeated_recursive_field,json=repeatedRecursiveField,proto3" json:"repeated_recursive_field,omitempty"`
 	// Ensure that FieldOptions can be defined using package name resolution that starts from the
@@ -527,7 +527,7 @@ func (*PaintSpec_RecursiveType) Descriptor() ([]byte, []int) {
 	return file_github_com_solo_io_skv2_codegen_test_test_api_proto_rawDescGZIP(), []int{0, 0}
 }
 
-func (x *PaintSpec_RecursiveType) GetProtobufValue() *_struct.Value {
+func (x *PaintSpec_RecursiveType) GetProtobufValue() *structpb.Value {
 	if x != nil {
 		return x.ProtobufValue
 	}
@@ -746,9 +746,9 @@ var file_github_com_solo_io_skv2_codegen_test_test_api_proto_goTypes = []interfa
 	(*PaintSpec_RecursiveType)(nil), // 7: things.test.io.PaintSpec.RecursiveType
 	nil,                             // 8: things.test.io.PaintStatus.NearbyPaintsEntry
 	(*PaintStatus_Location)(nil),    // 9: things.test.io.PaintStatus.Location
-	(*any1.Any)(nil),                // 10: google.protobuf.Any
-	(*wrappers.StringValue)(nil),    // 11: google.protobuf.StringValue
-	(*_struct.Value)(nil),           // 12: google.protobuf.Value
+	(*anypb.Any)(nil),               // 10: google.protobuf.Any
+	(*wrapperspb.StringValue)(nil),  // 11: google.protobuf.StringValue
+	(*structpb.Value)(nil),          // 12: google.protobuf.Value
 }
 var file_github_com_solo_io_skv2_codegen_test_test_api_proto_depIdxs = []int32{
 	2,  // 0: things.test.io.PaintSpec.color:type_name -> things.test.io.PaintColor

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/solo-io/go-list-licenses v0.0.4
 	github.com/solo-io/go-utils v0.21.4
 	github.com/solo-io/k8s-utils v0.0.1
-	github.com/solo-io/protoc-gen-ext v0.0.18
+	github.com/solo-io/protoc-gen-ext v0.0.20-0.20240610195035-6e88af6fc769
 	github.com/solo-io/protoc-gen-openapi v0.2.4
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/solo-io/go-list-licenses v0.0.4
 	github.com/solo-io/go-utils v0.21.4
 	github.com/solo-io/k8s-utils v0.0.1
-	github.com/solo-io/protoc-gen-ext v0.0.20-0.20240610195035-6e88af6fc769
+	github.com/solo-io/protoc-gen-ext v0.0.20
 	github.com/solo-io/protoc-gen-openapi v0.2.4
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -814,8 +814,8 @@ github.com/solo-io/go-utils v0.21.4 h1:BUOrGNV+zQGIEKTS02SyPqevmkyG+AMl+0+czBg9a
 github.com/solo-io/go-utils v0.21.4/go.mod h1:6e8K1spnMWwlnJRSNp/J84GEyJbrcK4Gm7i+ehzCi8c=
 github.com/solo-io/k8s-utils v0.0.1 h1:e2alFsqTT7GU10d6cFDX2y+86J142DrsRwy5itvvZOI=
 github.com/solo-io/k8s-utils v0.0.1/go.mod h1:53N9+9Gl2MwqIZJ7/ocA9gKvWt+6z7MPD2qKQix7oFE=
-github.com/solo-io/protoc-gen-ext v0.0.18 h1:zSAL8NzWpJUGYoA5IyjHiKASNyHjR0uxBQ7eQS94i3A=
-github.com/solo-io/protoc-gen-ext v0.0.18/go.mod h1:iGyCvmKmhJNXs5MgBcYFBF0om7LDnCVD2WwhOZGnqeA=
+github.com/solo-io/protoc-gen-ext v0.0.20-0.20240610195035-6e88af6fc769 h1:B1x91gFzZef87x0U8gcrAFCRM0nNwK86p3GyuwMV/N0=
+github.com/solo-io/protoc-gen-ext v0.0.20-0.20240610195035-6e88af6fc769/go.mod h1:iGyCvmKmhJNXs5MgBcYFBF0om7LDnCVD2WwhOZGnqeA=
 github.com/solo-io/protoc-gen-openapi v0.2.4 h1:9tqGhCAq83IRSzHhKDzpWnPlbPPORTM2izVxjLk0Ftw=
 github.com/solo-io/protoc-gen-openapi v0.2.4/go.mod h1:osEjRl1miHqlq4Wl/8SEqHFoyydptPL1EzEdM9c4vfE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/go.sum
+++ b/go.sum
@@ -814,8 +814,8 @@ github.com/solo-io/go-utils v0.21.4 h1:BUOrGNV+zQGIEKTS02SyPqevmkyG+AMl+0+czBg9a
 github.com/solo-io/go-utils v0.21.4/go.mod h1:6e8K1spnMWwlnJRSNp/J84GEyJbrcK4Gm7i+ehzCi8c=
 github.com/solo-io/k8s-utils v0.0.1 h1:e2alFsqTT7GU10d6cFDX2y+86J142DrsRwy5itvvZOI=
 github.com/solo-io/k8s-utils v0.0.1/go.mod h1:53N9+9Gl2MwqIZJ7/ocA9gKvWt+6z7MPD2qKQix7oFE=
-github.com/solo-io/protoc-gen-ext v0.0.20-0.20240610195035-6e88af6fc769 h1:B1x91gFzZef87x0U8gcrAFCRM0nNwK86p3GyuwMV/N0=
-github.com/solo-io/protoc-gen-ext v0.0.20-0.20240610195035-6e88af6fc769/go.mod h1:iGyCvmKmhJNXs5MgBcYFBF0om7LDnCVD2WwhOZGnqeA=
+github.com/solo-io/protoc-gen-ext v0.0.20 h1:0cE+DvIp7G97/xlETL3didPQ1s5SHav5mkebljXk/Ws=
+github.com/solo-io/protoc-gen-ext v0.0.20/go.mod h1:iGyCvmKmhJNXs5MgBcYFBF0om7LDnCVD2WwhOZGnqeA=
 github.com/solo-io/protoc-gen-openapi v0.2.4 h1:9tqGhCAq83IRSzHhKDzpWnPlbPPORTM2izVxjLk0Ftw=
 github.com/solo-io/protoc-gen-openapi v0.2.4/go.mod h1:osEjRl1miHqlq4Wl/8SEqHFoyydptPL1EzEdM9c4vfE=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pkg/api/core.skv2.solo.io/v1/core.pb.clone.go
+++ b/pkg/api/core.skv2.solo.io/v1/core.pb.clone.go
@@ -13,9 +13,9 @@ import (
 	"github.com/solo-io/protoc-gen-ext/pkg/clone"
 	"google.golang.org/protobuf/proto"
 
-	github_com_golang_protobuf_ptypes_timestamp "github.com/golang/protobuf/ptypes/timestamp"
+	google_golang_org_protobuf_types_known_timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 
-	github_com_golang_protobuf_ptypes_wrappers "github.com/golang/protobuf/ptypes/wrappers"
+	google_golang_org_protobuf_types_known_wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // ensure the imports are used
@@ -94,15 +94,15 @@ func (m *TypedObjectRef) Clone() proto.Message {
 	target = &TypedObjectRef{}
 
 	if h, ok := interface{}(m.GetApiGroup()).(clone.Cloner); ok {
-		target.ApiGroup = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.ApiGroup = h.Clone().(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	} else {
-		target.ApiGroup = proto.Clone(m.GetApiGroup()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.ApiGroup = proto.Clone(m.GetApiGroup()).(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	}
 
 	if h, ok := interface{}(m.GetKind()).(clone.Cloner); ok {
-		target.Kind = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.Kind = h.Clone().(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	} else {
-		target.Kind = proto.Clone(m.GetKind()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.Kind = proto.Clone(m.GetKind()).(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	}
 
 	target.Name = m.GetName()
@@ -121,15 +121,15 @@ func (m *TypedClusterObjectRef) Clone() proto.Message {
 	target = &TypedClusterObjectRef{}
 
 	if h, ok := interface{}(m.GetApiGroup()).(clone.Cloner); ok {
-		target.ApiGroup = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.ApiGroup = h.Clone().(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	} else {
-		target.ApiGroup = proto.Clone(m.GetApiGroup()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.ApiGroup = proto.Clone(m.GetApiGroup()).(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	}
 
 	if h, ok := interface{}(m.GetKind()).(clone.Cloner); ok {
-		target.Kind = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.Kind = h.Clone().(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	} else {
-		target.Kind = proto.Clone(m.GetKind()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.Kind = proto.Clone(m.GetKind()).(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	}
 
 	target.Name = m.GetName()
@@ -156,15 +156,15 @@ func (m *Status) Clone() proto.Message {
 	target.ObservedGeneration = m.GetObservedGeneration()
 
 	if h, ok := interface{}(m.GetProcessingTime()).(clone.Cloner); ok {
-		target.ProcessingTime = h.Clone().(*github_com_golang_protobuf_ptypes_timestamp.Timestamp)
+		target.ProcessingTime = h.Clone().(*google_golang_org_protobuf_types_known_timestamppb.Timestamp)
 	} else {
-		target.ProcessingTime = proto.Clone(m.GetProcessingTime()).(*github_com_golang_protobuf_ptypes_timestamp.Timestamp)
+		target.ProcessingTime = proto.Clone(m.GetProcessingTime()).(*google_golang_org_protobuf_types_known_timestamppb.Timestamp)
 	}
 
 	if h, ok := interface{}(m.GetOwner()).(clone.Cloner); ok {
-		target.Owner = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.Owner = h.Clone().(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	} else {
-		target.Owner = proto.Clone(m.GetOwner()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.Owner = proto.Clone(m.GetOwner()).(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	}
 
 	return target
@@ -227,9 +227,9 @@ func (m *PolicyTargetReference) Clone() proto.Message {
 	target.Name = m.GetName()
 
 	if h, ok := interface{}(m.GetNamespace()).(clone.Cloner); ok {
-		target.Namespace = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.Namespace = h.Clone().(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	} else {
-		target.Namespace = proto.Clone(m.GetNamespace()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.Namespace = proto.Clone(m.GetNamespace()).(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	}
 
 	return target
@@ -250,15 +250,15 @@ func (m *PolicyTargetReferenceWithSectionName) Clone() proto.Message {
 	target.Name = m.GetName()
 
 	if h, ok := interface{}(m.GetNamespace()).(clone.Cloner); ok {
-		target.Namespace = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.Namespace = h.Clone().(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	} else {
-		target.Namespace = proto.Clone(m.GetNamespace()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.Namespace = proto.Clone(m.GetNamespace()).(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	}
 
 	if h, ok := interface{}(m.GetSectionName()).(clone.Cloner); ok {
-		target.SectionName = h.Clone().(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.SectionName = h.Clone().(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	} else {
-		target.SectionName = proto.Clone(m.GetSectionName()).(*github_com_golang_protobuf_ptypes_wrappers.StringValue)
+		target.SectionName = proto.Clone(m.GetSectionName()).(*google_golang_org_protobuf_types_known_wrapperspb.StringValue)
 	}
 
 	return target

--- a/pkg/api/core.skv2.solo.io/v1/core.pb.go
+++ b/pkg/api/core.skv2.solo.io/v1/core.pb.go
@@ -10,11 +10,11 @@ import (
 	reflect "reflect"
 	sync "sync"
 
-	timestamp "github.com/golang/protobuf/ptypes/timestamp"
-	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 	_ "github.com/solo-io/protoc-gen-ext/extproto"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 const (
@@ -343,9 +343,9 @@ type TypedObjectRef struct {
 	unknownFields protoimpl.UnknownFields
 
 	// API group of the resource being referenced
-	ApiGroup *wrappers.StringValue `protobuf:"bytes,1,opt,name=api_group,json=apiGroup,proto3" json:"api_group,omitempty"`
+	ApiGroup *wrapperspb.StringValue `protobuf:"bytes,1,opt,name=api_group,json=apiGroup,proto3" json:"api_group,omitempty"`
 	// Kind of the resource being referenced
-	Kind *wrappers.StringValue `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Kind *wrapperspb.StringValue `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
 	// name of the resource being referenced
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// namespace of the resource being referenced
@@ -384,14 +384,14 @@ func (*TypedObjectRef) Descriptor() ([]byte, []int) {
 	return file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *TypedObjectRef) GetApiGroup() *wrappers.StringValue {
+func (x *TypedObjectRef) GetApiGroup() *wrapperspb.StringValue {
 	if x != nil {
 		return x.ApiGroup
 	}
 	return nil
 }
 
-func (x *TypedObjectRef) GetKind() *wrappers.StringValue {
+func (x *TypedObjectRef) GetKind() *wrapperspb.StringValue {
 	if x != nil {
 		return x.Kind
 	}
@@ -419,9 +419,9 @@ type TypedClusterObjectRef struct {
 	unknownFields protoimpl.UnknownFields
 
 	// API group of the resource being referenced
-	ApiGroup *wrappers.StringValue `protobuf:"bytes,1,opt,name=api_group,json=apiGroup,proto3" json:"api_group,omitempty"`
+	ApiGroup *wrapperspb.StringValue `protobuf:"bytes,1,opt,name=api_group,json=apiGroup,proto3" json:"api_group,omitempty"`
 	// Kind of the resource being referenced
-	Kind *wrappers.StringValue `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
+	Kind *wrapperspb.StringValue `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
 	// name of the resource being referenced
 	Name string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// namespace of the resource being referenced
@@ -462,14 +462,14 @@ func (*TypedClusterObjectRef) Descriptor() ([]byte, []int) {
 	return file_github_com_solo_io_skv2_api_core_v1_core_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *TypedClusterObjectRef) GetApiGroup() *wrappers.StringValue {
+func (x *TypedClusterObjectRef) GetApiGroup() *wrapperspb.StringValue {
 	if x != nil {
 		return x.ApiGroup
 	}
 	return nil
 }
 
-func (x *TypedClusterObjectRef) GetKind() *wrappers.StringValue {
+func (x *TypedClusterObjectRef) GetKind() *wrapperspb.StringValue {
 	if x != nil {
 		return x.Kind
 	}
@@ -511,10 +511,10 @@ type Status struct {
 	// a kubernetes resource
 	ObservedGeneration int64 `protobuf:"varint,3,opt,name=observed_generation,json=observedGeneration,proto3" json:"observed_generation,omitempty"`
 	// The time at which this status was recorded
-	ProcessingTime *timestamp.Timestamp `protobuf:"bytes,4,opt,name=processing_time,json=processingTime,proto3" json:"processing_time,omitempty"`
+	ProcessingTime *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=processing_time,json=processingTime,proto3" json:"processing_time,omitempty"`
 	// (optional) The owner of the status, this value can be used to identify the entity which wrote this status.
 	// This is useful in situations where a given resource may have multiple owners.
-	Owner *wrappers.StringValue `protobuf:"bytes,5,opt,name=owner,proto3" json:"owner,omitempty"`
+	Owner *wrapperspb.StringValue `protobuf:"bytes,5,opt,name=owner,proto3" json:"owner,omitempty"`
 }
 
 func (x *Status) Reset() {
@@ -570,14 +570,14 @@ func (x *Status) GetObservedGeneration() int64 {
 	return 0
 }
 
-func (x *Status) GetProcessingTime() *timestamp.Timestamp {
+func (x *Status) GetProcessingTime() *timestamppb.Timestamp {
 	if x != nil {
 		return x.ProcessingTime
 	}
 	return nil
 }
 
-func (x *Status) GetOwner() *wrappers.StringValue {
+func (x *Status) GetOwner() *wrapperspb.StringValue {
 	if x != nil {
 		return x.Owner
 	}
@@ -669,7 +669,7 @@ type PolicyTargetReference struct {
 	Kind  string `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
 	Name  string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// Optional, if unspecified, the local namespace of the policy is inferred.
-	Namespace *wrappers.StringValue `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Namespace *wrapperspb.StringValue `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
 }
 
 func (x *PolicyTargetReference) Reset() {
@@ -725,7 +725,7 @@ func (x *PolicyTargetReference) GetName() string {
 	return ""
 }
 
-func (x *PolicyTargetReference) GetNamespace() *wrappers.StringValue {
+func (x *PolicyTargetReference) GetNamespace() *wrapperspb.StringValue {
 	if x != nil {
 		return x.Namespace
 	}
@@ -747,10 +747,10 @@ type PolicyTargetReferenceWithSectionName struct {
 	Kind  string `protobuf:"bytes,2,opt,name=kind,proto3" json:"kind,omitempty"`
 	Name  string `protobuf:"bytes,3,opt,name=name,proto3" json:"name,omitempty"`
 	// Optional, if unspecified, the local namespace of the policy is inferred.
-	Namespace *wrappers.StringValue `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	Namespace *wrapperspb.StringValue `protobuf:"bytes,4,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	// Name of the section within the targeted resource to attach to. For `Gateway` resources, this refers to a `Listener` name.
 	// Optional, if unspecified, the entire object referenced is selected.
-	SectionName *wrappers.StringValue `protobuf:"bytes,5,opt,name=section_name,json=sectionName,proto3" json:"section_name,omitempty"`
+	SectionName *wrapperspb.StringValue `protobuf:"bytes,5,opt,name=section_name,json=sectionName,proto3" json:"section_name,omitempty"`
 }
 
 func (x *PolicyTargetReferenceWithSectionName) Reset() {
@@ -806,14 +806,14 @@ func (x *PolicyTargetReferenceWithSectionName) GetName() string {
 	return ""
 }
 
-func (x *PolicyTargetReferenceWithSectionName) GetNamespace() *wrappers.StringValue {
+func (x *PolicyTargetReferenceWithSectionName) GetNamespace() *wrapperspb.StringValue {
 	if x != nil {
 		return x.Namespace
 	}
 	return nil
 }
 
-func (x *PolicyTargetReferenceWithSectionName) GetSectionName() *wrappers.StringValue {
+func (x *PolicyTargetReferenceWithSectionName) GetSectionName() *wrapperspb.StringValue {
 	if x != nil {
 		return x.SectionName
 	}
@@ -1052,8 +1052,8 @@ var file_github_com_solo_io_skv2_api_core_v1_core_proto_goTypes = []interface{}{
 	(*PolicyTargetReferenceWithSectionName)(nil), // 10: core.skv2.solo.io.PolicyTargetReferenceWithSectionName
 	nil,                               // 11: core.skv2.solo.io.ObjectSelector.LabelsEntry
 	(*ObjectSelector_Expression)(nil), // 12: core.skv2.solo.io.ObjectSelector.Expression
-	(*wrappers.StringValue)(nil),      // 13: google.protobuf.StringValue
-	(*timestamp.Timestamp)(nil),       // 14: google.protobuf.Timestamp
+	(*wrapperspb.StringValue)(nil),    // 13: google.protobuf.StringValue
+	(*timestamppb.Timestamp)(nil),     // 14: google.protobuf.Timestamp
 }
 var file_github_com_solo_io_skv2_api_core_v1_core_proto_depIdxs = []int32{
 	2,  // 0: core.skv2.solo.io.ObjectRefList.refs:type_name -> core.skv2.solo.io.ObjectRef


### PR DESCRIPTION
# Description
Add a parameter to support editing the fullPackageName value used for hashing.

# Context
Changing the package of the generated files has the unintended consequence of changing the hash output for messages. We need the option to edit the package name in order to maintain the old hashing logic and not cause unintentional discrepancies.

Depends on https://github.com/solo-io/protoc-gen-ext/pull/23