### PR TITLE
Global floatingUserId

### DIFF
--- a/changelog/v0.40.5/globalFloatingUserId_in_delpoyment_templates.yaml
+++ b/changelog/v0.40.5/globalFloatingUserId_in_delpoyment_templates.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/5034
+    resolvesIssue: false
+    description: |
+      Adds the ability to render deployments templates with a reference global floatingUserId field. This field is used to globally unset
+      the runAsUser field in container securityContexts (like the painter's floatingUserId) and supresses the rendering of the
+      pod's securityContext. This feature is enabled by setting the GlobalFloatingUserIdPath in the Operator to the path of the global field,
+      and defaults to an empty string.

--- a/codegen/cmd_test.go
+++ b/codegen/cmd_test.go
@@ -2341,6 +2341,105 @@ roleRef:
 			}),
 	)
 
+	DescribeTable("rendering with GlobalFloatingUserId",
+		func(floatingUserId bool) {
+			cmd := &Command{
+				Chart: &Chart{
+					Operators: []Operator{
+						{
+							Name: "painter",
+							Deployment: Deployment{
+								Container: Container{
+									Image: Image{
+										Tag:        "v0.0.0",
+										Repository: "painter",
+										Registry:   "quay.io/solo-io",
+										PullPolicy: "IfNotPresent",
+									},
+								},
+							},
+							GlobalFloatingUserIdPath: ".Values.global.securitySettings.floatingUserId",
+						},
+					},
+					// Because the global override comes from .Values it has to be set here, not on the painter
+					Values: map[string]interface{}{
+						"global": map[string]interface{}{
+							"securitySettings": map[string]interface{}{
+								"floatingUserId": floatingUserId,
+							},
+						},
+					},
+					Data: Data{
+						ApiVersion:  "v1",
+						Description: "",
+						Name:        "Painting Operator",
+						Version:     "v0.0.1",
+						Home:        "https://docs.solo.io/skv2/latest",
+						Sources: []string{
+							"https://github.com/solo-io/skv2",
+						},
+					},
+				},
+
+				ManifestRoot: "codegen/test/chart",
+			}
+
+			err := cmd.Execute()
+			Expect(err).NotTo(HaveOccurred())
+
+			runAsUser := 202020
+			runAsGroup := 999
+			painterValues := map[string]interface{}{
+				"enabled":   true,
+				"runAsUser": runAsUser,
+				"podSecurityContext": map[string]interface{}{
+					"runAsUser": runAsUser,
+					"fsGroup":   runAsGroup,
+				},
+			}
+
+			helmValues := map[string]interface{}{"painter": painterValues}
+
+			renderedManifests := helmTemplate("./codegen/test/chart", helmValues)
+
+			var renderedDeployment *appsv1.Deployment
+			decoder := kubeyaml.NewYAMLOrJSONDecoder(bytes.NewBuffer(renderedManifests), 4096)
+			for {
+				obj := &unstructured.Unstructured{}
+				err := decoder.Decode(obj)
+				if err != nil {
+					break
+				}
+				if obj.GetName() != "painter" || obj.GetKind() != "Deployment" {
+					continue
+				}
+
+				bytes, err := obj.MarshalJSON()
+				Expect(err).NotTo(HaveOccurred())
+				renderedDeployment = &appsv1.Deployment{}
+				err = json.Unmarshal(bytes, renderedDeployment)
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			Expect(renderedDeployment).NotTo(BeNil())
+			renderedRunAsUser := renderedDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser
+			renderedPodSecurityContext := renderedDeployment.Spec.Template.Spec.SecurityContext
+
+			// When using the global floatingUserId, the container runAsUser and RunAsUser should not be set
+			if floatingUserId {
+				Expect(renderedRunAsUser).To(BeNil())
+				Expect(renderedPodSecurityContext).To(BeNil())
+			} else {
+				Expect(*renderedRunAsUser).To(Equal(int64(runAsUser)))
+				Expect(*renderedPodSecurityContext.RunAsUser).To(Equal(int64(runAsUser)))
+				Expect(*renderedPodSecurityContext.FSGroup).To(Equal(int64(runAsGroup)))
+			}
+
+		},
+		Entry("Global floatingUserId is true", true),
+		Entry("Global floatingUserId is false", false),
+	)
+
 	Describe("rendering template env vars", func() {
 		var tmpDir string
 

--- a/codegen/model/chart.go
+++ b/codegen/model/chart.go
@@ -98,6 +98,9 @@ type Operator struct {
 	//
 	// E.g: `and (.Values.operator.customValueA) (.Values.operator.customValueB)`
 	CustomEnableCondition string
+
+	// Optional: if specified, will use this path in rendering template logic
+	GlobalFloatingUserIdPath string
 }
 
 func (o Operator) FormattedName() string {

--- a/codegen/templates/chart/operator-deployment.yamltmpl
+++ b/codegen/templates/chart/operator-deployment.yamltmpl
@@ -87,6 +87,10 @@ spec:
     spec:
       serviceAccountName: [[ $operator.Name ]]
       {{- /* Override the default podSecurityContext config if it is set. */}}
+[[- /* the GlobalFloatingUserId is expected to disable the pod security context */ -]]
+[[- if $operator.GlobalFloatingUserIdPath ]]
+{{- if not [[ $operator.GlobalFloatingUserIdPath ]] }}
+[[- end ]]
 {{- if or ([[ (opVar $operator) ]].podSecurityContext) (eq "map[]" (printf "%v" [[ (opVar $operator) ]].podSecurityContext)) }}
       securityContext:
 {{ toYaml [[ (opVar $operator) ]].podSecurityContext | indent 8 }}
@@ -96,6 +100,9 @@ spec:
 [[ toYaml $podSecurityContext | indent 8 ]]
 [[- end ]]
 {{- end }}
+[[- if $operator.GlobalFloatingUserIdPath ]] [[/* end the "if" if GlobalFloatingUserId is being checked */]]
+{{- end }}
+[[- end ]]
 [[- if $volumes ]]
       volumes:
 [[ toYaml $volumes | indent 6 ]]
@@ -201,7 +208,12 @@ spec:
           {}
 {{- else}}
           runAsNonRoot: true
+          [[- /* if there is a GlobalFloatingUserIdPath add it to the runAsuser logic */ -]]
+          [[- if $operator.GlobalFloatingUserIdPath ]]
+          {{- if not (or $[[ $operatorVar ]].floatingUserId [[ $operator.GlobalFloatingUserIdPath ]]) }}
+          [[- else ]]
           {{- if not $[[ $operatorVar ]].floatingUserId }}
+          [[- end ]]
           runAsUser: {{ printf "%.0f" (float64 $[[ $operatorVar ]].runAsUser) }}
           {{- end }}
           readOnlyRootFilesystem: true


### PR DESCRIPTION
# Description
 Adds the ability to render deployments templates with a reference global floatingUserId field. This field is used to globally unset  the runAsUser field in container securityContexts (like the painter's floatingUserId) and supresses the rendering of the pod's securityContext.

This feature is enabled by setting the GlobalFloatingUserIdPath in the Operator to the path of the global field, and defaults to an empty string (disabled).

# Context
This has been added to [facilitate OpenShift deployments](https://github.com/solo-io/gloo/issues/5034) by creating a single field that can apply the changes necessary to deploy with OpenShift. The template generation is used by Gloo Gateway EE to create its Portal deployments, and this change will allow the global setting to be applied.

Example usage: https://github.com/solo-io/solo-projects/compare/consistent-floating-user-id...consistent-floating-user-id-with-portal-operator

# Manual validation
There is a [solo-projects PR](https://github.com/solo-io/solo-projects/pull/6682) that has the non-skv2 related Helm changes to support the new global flag for OpenShift which has been [validated by Field Engingeering](https://solo-io-corp.slack.com/archives/C07EA6J3N1Y/p1723128160971599?thread_ts=1723064483.816289&cid=C07EA6J3N1Y). Because the skv2 generated templated has not been updated, `gateway-portal-web-server.glooPortalServer. floatingUserId=true` needs to be set.

The approach for this test is to generate the Helm from that branch with `gateway-portal-web-server.glooPortalServer. floatingUserId=true` and use it as the baseline against which to validate the skv2 changes.

We will then generate helm in that branch without `gateway-portal-web-server.glooPortalServer. floatingUserId=true` to see the changes from not including that flag - runAsUser is rendered for the portal, and we can ignore the generated security artifacts:
```
diff /tmp/openshift-compatible-helm.yaml /tmp/broken-portal-helm.yaml
72c72
<   signing-key: "akNjQVdvM0thSQ=="
---
>   signing-key: "VUJ5b3lKR3UySg=="
85,86c85,86
<   users.acl: dXNlciBkZWZhdWx0ICtAYWxsIGFsbGtleXMgb24gPldJc014UTc2NE02Q1Y1NUlKWFBxd1REQVB3djRPSGs1eW9MTkh6U0diWnMxcG9lUmRicmkwRGZsRGRtYmUxU3g=
<   redis-password: V0lzTXhRNzY0TTZDVjU1SUpYUHF3VERBUHd2NE9IazV5b0xOSHpTR2JaczFwb2VSZGJyaTBEZmxEZG1iZTFTeA==
---
>   users.acl: dXNlciBkZWZhdWx0ICtAYWxsIGFsbGtleXMgb24gPlh5c3R5OHdjWjl2N084Ynp3NjN2cG5aRzJOeXh4bG41Sk51enpmZHZqcm9HT3FacU5BNFRFZG1RS1NoZmpBNlo=
>   redis-password: WHlzdHk4d2NaOXY3Tzhienc2M3ZwblpHMk55eHhsbjVKTnV6emZkdmpyb0dPcVpxTkE0VEVkbVFLU2hmakE2Wg==
1721a1722
>           runAsUser: 10101
```

We then switch to a fork of that branch which has had the SKv2 changes pulled in an regenerate the Helm without `gateway-portal-web-server.glooPortalServer. floatingUserId=true` and validate that it matches the original helm ( ignoring the generated security artifacts)

```
diff /tmp/openshift-compatible-helm.yaml /tmp/new-portal-helm.yaml
72c72
<   signing-key: "akNjQVdvM0thSQ=="
---
>   signing-key: "ZXZEV0VBR0drSQ=="
85,86c85,86
<   users.acl: dXNlciBkZWZhdWx0ICtAYWxsIGFsbGtleXMgb24gPldJc014UTc2NE02Q1Y1NUlKWFBxd1REQVB3djRPSGs1eW9MTkh6U0diWnMxcG9lUmRicmkwRGZsRGRtYmUxU3g=
<   redis-password: V0lzTXhRNzY0TTZDVjU1SUpYUHF3VERBUHd2NE9IazV5b0xOSHpTR2JaczFwb2VSZGJyaTBEZmxEZG1iZTFTeA==
---
>   users.acl: dXNlciBkZWZhdWx0ICtAYWxsIGFsbGtleXMgb24gPmt1aEF5RjFzdkxhWktXSGh0MnJDTlhrN3A5dE5JaER2aGIyOHRBZFRRSnhJY1cxa1BnVnJJQWQ3bEFOV0x6MDE=
>   redis-password: a3VoQXlGMXN2TGFaS1dIaHQyckNOWGs3cDl0TkloRHZoYjI4dEFkVFFKeEljVzFrUGdWcklBZDdsQU5XTHowMQ==
``` 

We are now rendering the OpenShift-compatible helm without the 

<details>

<summary>
Script to generate and diff helm. Expand to see results:

```
# This script generates helm templates for OpenShift in the following configurations:
# 1) Using the consistent-floating-user-id branch with "gateway-portal-web-server.glooPortalServer.floatingUserId=true" and "global.securitySettings.floatingUserId=true".
#    - this has been validated by Field Engineer to work with OpenShift and will be used as the "target" helm
# 2) Using the consistent-floating-user-id branch with "global.securitySettings.floatingUserId=true" and "gateway-portal-web-server.glooPortalServer.floatingUserId" as the default (false)
#    - this will show the results of this configuration do not provide the expected helm
# 3) Using the consistent-floating-user-id-with-portal-operator which has the skv2 changes pulled in and the same Helm values as 2)
#    - this will show that the skv2 changes result in rendering the desired Helm without needing to set "gateway-portal-web-server.glooPortalServer.floatingUserId=true"

echo "git checkout consistent-floating-user-id - this branch has been validated by field engineering"
git checkout consistent-floating-user-id

echo "VERSION=1.0.0-ci make build-test-chart"
VERSION=1.0.0-ci make build-test-chart > /dev/null

echo "\ncreating /tmp/helm-values-with-portal-floating-userid.yaml"

cat << EOF > /tmp/helm-values-with-portal-floating-userid.yaml
gloo:
  kubeGateway:
    enabled: true
  gatewayProxies:
    gatewayProxy:
      disabled: true
  gateway:
    persistProxySpec: true
    logLevel: info
    validation:
      alwaysAcceptResources: false
  gloo:
    logLevel: info
    deployment:
      replicas: 1
      customEnv:
        - name: GG_PORTAL_PLUGIN
          value: "true"
      livenessProbeEnabled: true
  discovery:
    enabled: false
  rbac:
    namespaced: true
    nameSuffix: gg-demo
observability:
  enabled: false
prometheus:
  enabled: false
grafana:
  defaultInstallationEnabled: false
gloo-fed:
  enabled: false
  glooFedApiserver:
    enable: false
gateway-portal-web-server:
  enabled: true
  glooPortalServer:
    floatingUserId: true # <-------------------- SHOULD NOT BE NEEDED
settings:
  disableKubernetesDestinations: true
global:
  securitySettings:
    floatingUserId: true
  extensions:
    rateLimit:
      enabled: true
    extAuth:
      enabled: true
  istioSDS:
    enabled: true
  istioIntegration:
    enabled: true
    enableAutoMtls: true
EOF

echo "\nFile contents:"
cat /tmp/helm-values-with-portal-floating-userid.yaml


echo "\ncreating /tmp/helm-values-without-portal-floating-userid.yaml"

cat << EOF > /tmp/helm-values-without-portal-floating-userid.yaml
gloo:
  kubeGateway:
    enabled: true
  gatewayProxies:
    gatewayProxy:
      disabled: true
  gateway:
    persistProxySpec: true
    logLevel: info
    validation:
      alwaysAcceptResources: false
  gloo:
    logLevel: info
    deployment:
      replicas: 1
      customEnv:
        - name: GG_PORTAL_PLUGIN
          value: "true"
      livenessProbeEnabled: true
  discovery:
    enabled: false
  rbac:
    namespaced: true
    nameSuffix: gg-demo
observability:
  enabled: false
prometheus:
  enabled: false
grafana:
  defaultInstallationEnabled: false
gloo-fed:
  enabled: false
  glooFedApiserver:
    enable: false
gateway-portal-web-server:
  enabled: true
settings:
  disableKubernetesDestinations: true
global:
  securitySettings:
    floatingUserId: true
  extensions:
    rateLimit:
      enabled: true
    extAuth:
      enabled: true
  istioSDS:
    enabled: true
  istioIntegration:
    enabled: true
    enableAutoMtls: true
EOF

echo "\nFile contents:"
cat /tmp/helm-values-without-portal-floating-userid.yaml

echo "\n\nGenerating templates with glooPortalServer.floatingUserId=true - this is the 'target' chart that is known to work in OpenShift"
echo "helm template gloo-ee _test/gloo-ee-1.0.0-ci.tgz --namespace gloo-system --set-string license_key=$GLOO_LICENSE_KEY -f /tmp/helm-values-with-portal-floating-userid.yaml > /tmp/openshift-compatible-helm.yaml"
helm template gloo-ee _test/gloo-ee-1.0.0-ci.tgz --namespace gloo-system --set-string license_key=$GLOO_LICENSE_KEY -f /tmp/helm-values-with-portal-floating-userid.yaml > /tmp/openshift-compatible-helm.yaml

echo "\n\nGenerating templates without glooPortalServer.floatingUserId - this is the is to show the effects of the glooPortalServer.floatingUserId field"
echo "helm template gloo-ee _test/gloo-ee-1.0.0-ci.tgz --namespace gloo-system --set-string license_key=$GLOO_LICENSE_KEY -f /tmp/helm-values-without-portal-floating-userid.yaml > /tmp/broken-portal-helm.yaml"
helm template gloo-ee _test/gloo-ee-1.0.0-ci.tgz  --namespace gloo-system --set-string license_key=$GLOO_LICENSE_KEY -f /tmp/helm-values-without-portal-floating-userid.yaml > /tmp/broken-portal-helm.yaml


echo "\nGenerating diff - expecting to see runAsUser from the portal security context:"
echo "diff /tmp/openshift-compatible-helm.yaml /tmp/broken-portal-helm.yaml"
diff /tmp/openshift-compatible-helm.yaml /tmp/broken-portal-helm.yaml

echo "\n Checking out branch with SKv2 updates:"
echo "git checkout consistent-floating-user-id-with-portal-operator"
git checkout consistent-floating-user-id-with-portal-operator

echo "VERSION=1.0.0-ci make build-test-chart"
VERSION=1.0.0-ci make build-test-chart > /dev/null

echo "\n\nRe-generating templates without glooPortalServer.floatingUserId - this should match the original helm"
echo "helm template gloo-ee _test/gloo-ee-1.0.0-ci.tgz --namespace gloo-system --set-string license_key=$GLOO_LICENSE_KEY -f /tmp/helm-values-without-portal-floating-userid.yaml > /tmp/new-portal-helm.yaml"
helm template gloo-ee _test/gloo-ee-1.0.0-ci.tgz  --namespace gloo-system --set-string license_key=$GLOO_LICENSE_KEY -f /tmp/helm-values-without-portal-floating-userid.yaml > /tmp/new-portal-helm.yaml

echo "\nGenerating diff - should match target helm except for generated security artifacts:"
echo "diff /tmp/openshift-compatible-helm.yaml /tmp/new-portal-helm.yaml"
diff /tmp/openshift-compatible-helm.yaml /tmp/new-portal-helm.yaml

echo "\nCleanup"
rm /tmp/helm-values-with-portal-floating-userid.yaml /tmp/helm-values-without-portal-floating-userid.yaml /tmp/openshift-compatible-helm.yaml /tmp/broken-portal-helm.yaml  /tmp/new-portal-helm.yaml
```

</summary>
Results:

```
git checkout consistent-floating-user-id - this branch has been validated by field engineering
Switched to branch 'consistent-floating-user-id'
Your branch is up to date with 'origin/consistent-floating-user-id'.
VERSION=1.0.0-ci make build-test-chart

creating /tmp/helm-values-with-portal-floating-userid.yaml

File contents:
gloo:
  kubeGateway:
    enabled: true
  gatewayProxies:
    gatewayProxy:
      disabled: true
  gateway:
    persistProxySpec: true
    logLevel: info
    validation:
      alwaysAcceptResources: false
  gloo:
    logLevel: info
    deployment:
      replicas: 1
      customEnv:
        - name: GG_PORTAL_PLUGIN
          value: "true"
      livenessProbeEnabled: true
  discovery:
    enabled: false
  rbac:
    namespaced: true
    nameSuffix: gg-demo
observability:
  enabled: false
prometheus:
  enabled: false
grafana:
  defaultInstallationEnabled: false
gloo-fed:
  enabled: false
  glooFedApiserver:
    enable: false
gateway-portal-web-server:
  enabled: true
  glooPortalServer:
    floatingUserId: true # <-------------------- SHOULD NOT BE NEEDED
settings:
  disableKubernetesDestinations: true
global:
  securitySettings:
    floatingUserId: true
  extensions:
    rateLimit:
      enabled: true
    extAuth:
      enabled: true
  istioSDS:
    enabled: true
  istioIntegration:
    enabled: true
    enableAutoMtls: true

creating /tmp/helm-values-without-portal-floating-userid.yaml

File contents:
gloo:
  kubeGateway:
    enabled: true
  gatewayProxies:
    gatewayProxy:
      disabled: true
  gateway:
    persistProxySpec: true
    logLevel: info
    validation:
      alwaysAcceptResources: false
  gloo:
    logLevel: info
    deployment:
      replicas: 1
      customEnv:
        - name: GG_PORTAL_PLUGIN
          value: "true"
      livenessProbeEnabled: true
  discovery:
    enabled: false
  rbac:
    namespaced: true
    nameSuffix: gg-demo
observability:
  enabled: false
prometheus:
  enabled: false
grafana:
  defaultInstallationEnabled: false
gloo-fed:
  enabled: false
  glooFedApiserver:
    enable: false
gateway-portal-web-server:
  enabled: true
settings:
  disableKubernetesDestinations: true
global:
  securitySettings:
    floatingUserId: true
  extensions:
    rateLimit:
      enabled: true
    extAuth:
      enabled: true
  istioSDS:
    enabled: true
  istioIntegration:
    enabled: true
    enableAutoMtls: true


Generating templates with glooPortalServer.floatingUserId=true - this is the 'target' chart that is known to work in OpenShift
helm template gloo-ee _test/gloo-ee-1.0.0-ci.tgz --namespace gloo-system --set-string license_key=eyJhZGRPbnMiOltdLCJleHAiOjE3MjE4MzAwNTEsImlhdCI6MTcwNjI4MTY1MSwiayI6Ii90NDlLUSIsImx0IjoiZW50IiwicHJvZHVjdCI6Imdsb28ifQ.mWbudY_axUczC0chYLRpmX7hMNinUSg-SyIeVtBe12Y -f /tmp/helm-values-with-portal-floating-userid.yaml > /tmp/openshift-compatible-helm.yaml


Generating templates without glooPortalServer.floatingUserId - this is the is to show the effects of the glooPortalServer.floatingUserId field
helm template gloo-ee _test/gloo-ee-1.0.0-ci.tgz --namespace gloo-system --set-string license_key=eyJhZGRPbnMiOltdLCJleHAiOjE3MjE4MzAwNTEsImlhdCI6MTcwNjI4MTY1MSwiayI6Ii90NDlLUSIsImx0IjoiZW50IiwicHJvZHVjdCI6Imdsb28ifQ.mWbudY_axUczC0chYLRpmX7hMNinUSg-SyIeVtBe12Y -f /tmp/helm-values-without-portal-floating-userid.yaml > /tmp/broken-portal-helm.yaml

Generating diff - expecting to see runAsUser from the portal security context:
diff /tmp/openshift-compatible-helm.yaml /tmp/broken-portal-helm.yaml
72c72
<   signing-key: "TTkyZGg4UTB1Vg=="
---
>   signing-key: "b1c2RktpQWUyMA=="
85,86c85,86
<   users.acl: dXNlciBkZWZhdWx0ICtAYWxsIGFsbGtleXMgb24gPmtFY0RnVmFuRWJFT3FWRlRjcTB4Rmh6SVdlSWF5UE51Z3lscGZTb2N1S3V2MXdnVUE1N0NsRlRWWHIydEZIR0M=
<   redis-password: a0VjRGdWYW5FYkVPcVZGVGNxMHhGaHpJV2VJYXlQTnVneWxwZlNvY3VLdXYxd2dVQTU3Q2xGVFZYcjJ0RkhHQw==
---
>   users.acl: dXNlciBkZWZhdWx0ICtAYWxsIGFsbGtleXMgb24gPmQ4QzZVQUFnM1cyYktkb0xMT3N6ZTUyZWh3Z2R0OWRwWGpET3k4S05udW1DMm8wb2QzMEowYUVoMUNPd0xsYzc=
>   redis-password: ZDhDNlVBQWczVzJiS2RvTExPc3plNTJlaHdnZHQ5ZHBYakRPeThLTm51bUMybzBvZDMwSjBhRWgxQ093TGxjNw==
1721a1722
>           runAsUser: 10101

 Checking out branch with SKv2 updates:
git checkout consistent-floating-user-id-with-portal-operator
Switched to branch 'consistent-floating-user-id-with-portal-operator'
Your branch is up to date with 'origin/consistent-floating-user-id-with-portal-operator'.
VERSION=1.0.0-ci make build-test-chart


Re-generating templates without glooPortalServer.floatingUserId - this should match the original helm
helm template gloo-ee _test/gloo-ee-1.0.0-ci.tgz --namespace gloo-system --set-string license_key=eyJhZGRPbnMiOltdLCJleHAiOjE3MjE4MzAwNTEsImlhdCI6MTcwNjI4MTY1MSwiayI6Ii90NDlLUSIsImx0IjoiZW50IiwicHJvZHVjdCI6Imdsb28ifQ.mWbudY_axUczC0chYLRpmX7hMNinUSg-SyIeVtBe12Y -f /tmp/helm-values-without-portal-floating-userid.yaml > /tmp/new-portal-helm.yaml

Generating diff - should match target helm except for generated security artifacts:
diff /tmp/openshift-compatible-helm.yaml /tmp/new-portal-helm.yaml
72c72
<   signing-key: "TTkyZGg4UTB1Vg=="
---
>   signing-key: "ZldsczA4aDJudg=="
85,86c85,86
<   users.acl: dXNlciBkZWZhdWx0ICtAYWxsIGFsbGtleXMgb24gPmtFY0RnVmFuRWJFT3FWRlRjcTB4Rmh6SVdlSWF5UE51Z3lscGZTb2N1S3V2MXdnVUE1N0NsRlRWWHIydEZIR0M=
<   redis-password: a0VjRGdWYW5FYkVPcVZGVGNxMHhGaHpJV2VJYXlQTnVneWxwZlNvY3VLdXYxd2dVQTU3Q2xGVFZYcjJ0RkhHQw==
---
>   users.acl: dXNlciBkZWZhdWx0ICtAYWxsIGFsbGtleXMgb24gPkpQN2Y5cnZXWnlZdEp0TGJpc29tWlVFd0YzTXBuaGdmS1FvVm43c1I4TDhTUDhONDZmektsR3JYY25WbTJUQUY=
>   redis-password: SlA3ZjlydldaeVl0SnRMYmlzb21aVUV3RjNNcG5oZ2ZLUW9WbjdzUjhMOFNQOE40NmZ6S2xHclhjblZtMlRBRg==

Cleanup
```

</details>


