### PR TITLE
Backporting timeout fix

### DIFF
--- a/changelog/v0.32.2/backport-timeout-fix.yaml
+++ b/changelog/v0.32.2/backport-timeout-fix.yaml
@@ -1,4 +1,5 @@
 changelog:
 - type: FIX
-  description: 
-    Backporting timeout fix from 0.34.5.
+  description: Backporting timeout fix from 0.34.5.
+  issueLink: https://github.com/solo-io/solo-projects/issues/7909
+  resolvesIssue: false

--- a/changelog/v0.32.2/backport-timeout-fix.yaml
+++ b/changelog/v0.32.2/backport-timeout-fix.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: 
+    Backporting timeout fix from 0.34.5.

--- a/codegen/collector/extractor.go
+++ b/codegen/collector/extractor.go
@@ -87,9 +87,10 @@ func (i *synchronizedImportsExtractor) FetchImportsForFile(protoFile string, imp
 	i.activeRequestsMu.Unlock()
 
 	select {
-	case <-time.After(5 * time.Second):
-		// We should never reach this. This can only occur if we deadlock on file imports
-		// which only happens with cyclic dependencies
+	case <-time.After(15 * time.Second):
+		// We should never reach this in an ideal scenario. If we do, it means that
+		// we either have a deadlock or golang is being very slow.
+		// The deadlock occurs on file imports with cyclic dependencies.
 		// Perhaps a safer alternative to erroring is just to execute the importsFetcher:
 		// 	return importsFetcher(protoFile)
 		return nil, FetchImportsTimeout(protoFile)


### PR DESCRIPTION
# Description

While upgrading SP v1.15.x to Go 1.23 from Go 1.20, I'm seeing the same codegen timeout that we [encountered when upgrading to Go 1.21](https://github.com/solo-io/solo-projects/pull/5512). The [fix in v0.34.5](https://github.com/solo-io/skv2/pull/503) comes with some changes I don't want to pull into SP v1.15.x, so I'm cutting patch.