### PR TITLE
Bump proto gen timeout

### DIFF
--- a/changelog/v0.46.1/increase-protogen-timeout.yaml
+++ b/changelog/v0.46.1/increase-protogen-timeout.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/8953
+    resolvesIssue: false
+    description: |
+      Increase timeout for code generation.

--- a/codegen/collector/extractor.go
+++ b/codegen/collector/extractor.go
@@ -87,7 +87,7 @@ func (i *synchronizedImportsExtractor) FetchImportsForFile(protoFile string, imp
 	i.activeRequestsMu.Unlock()
 
 	select {
-	case <-time.After(15 * time.Second):
+	case <-time.After(45 * time.Second):
 		// We should never reach this in an ideal scenario. If we do, it means that
 		// we either have a deadlock or golang is being very slow.
 		// The deadlock occurs on file imports with cyclic dependencies.

--- a/codegen/collector/extractor.go
+++ b/codegen/collector/extractor.go
@@ -87,7 +87,7 @@ func (i *synchronizedImportsExtractor) FetchImportsForFile(protoFile string, imp
 	i.activeRequestsMu.Unlock()
 
 	select {
-	case <-time.After(45 * time.Second):
+	case <-time.After(90 * time.Second):
 		// We should never reach this in an ideal scenario. If we do, it means that
 		// we either have a deadlock or golang is being very slow.
 		// The deadlock occurs on file imports with cyclic dependencies.


### PR DESCRIPTION
Hitting this on an older M1 laptop. Check Point Endpoint Security may be playing a role in the slowness.